### PR TITLE
Type-safe seed file generation

### DIFF
--- a/src/commands/seed/make.mts
+++ b/src/commands/seed/make.mts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir } from 'node:fs/promises'
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises'
 import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { join } from 'pathe'
@@ -6,6 +6,10 @@ import { CommonArgs } from '../../arguments/common.mjs'
 import { ExtensionArg, assertExtension } from '../../arguments/extension.mjs'
 import { getConfigOrFail } from '../../config/get-config.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import {
+	getKyselyCodegenInstalledVersion,
+	getPrismaKyselyInstalledVersion,
+} from '../../utils/version.mjs'
 
 const args = {
 	...CommonArgs,
@@ -30,9 +34,9 @@ const BaseMakeCommand = {
 
 		assertExtension(extension)
 
-		const config = await getConfigOrFail(args)
+		const { seeds, ...config } = await getConfigOrFail(args)
 
-		const seedsFolderPath = join(config.cwd, config.seeds.seedFolder)
+		const seedsFolderPath = join(config.cwd, seeds.seedFolder)
 
 		consola.debug('Seeds folder path:', seedsFolderPath)
 
@@ -44,19 +48,58 @@ const BaseMakeCommand = {
 			consola.debug('Seeds folder created')
 		}
 
-		const filename = `${await config.seeds.getSeedPrefix()}${
+		const destinationFilename = `${await seeds.getSeedPrefix()}${
 			args.seed_name
 		}.${extension}`
 
-		consola.debug('Filename:', filename)
+		consola.debug('Destination filename:', destinationFilename)
 
-		const filePath = join(seedsFolderPath, filename)
+		const destinationFilePath = join(seedsFolderPath, destinationFilename)
 
-		consola.debug('File path:', filePath)
+		consola.debug('File path:', destinationFilePath)
 
-		await copyFile(join(__dirname, 'templates/seed-template.ts'), filePath)
+		const databaseInterfacePath =
+			seeds.databaseInterfacePath ||
+			((await getKyselyCodegenInstalledVersion(args))
+				? 'kysely-codegen'
+				: undefined)
 
-		consola.success(`Created seed file at ${filePath}`)
+		consola.debug('Database interface path:', databaseInterfacePath)
+
+		if (!databaseInterfacePath) {
+			await copyFile(
+				join(__dirname, 'templates/seed-template.ts'),
+				destinationFilePath,
+			)
+		} else {
+			const templateFile = await readFile(
+				join(__dirname, 'templates/seed-type-safe-template.ts'),
+				{ encoding: 'utf8' },
+			)
+
+			consola.debug('templateFile', templateFile)
+
+			const [
+				databaseInterfaceFilePath,
+				databaseInterfaceName = databaseInterfaceFilePath ===
+					'kysely-codegen' || (await getPrismaKyselyInstalledVersion(args))
+					? 'DB'
+					: 'Database',
+			] = databaseInterfacePath.split('#')
+
+			consola.debug('Database interface file path: ', databaseInterfaceFilePath)
+			consola.debug('Database interface name: ', databaseInterfaceName)
+
+			const populatedTemplateFile = templateFile
+				.replace(/<typename>/g, databaseInterfaceName)
+				.replace(/<path>/g, databaseInterfaceFilePath)
+
+			consola.debug('Populated template file: ', populatedTemplateFile)
+
+			await writeFile(destinationFilePath, populatedTemplateFile)
+		}
+
+		consola.success(`Created seed file at ${destinationFilePath}`)
 	},
 } satisfies CommandDef<typeof args>
 

--- a/src/config/kysely-ctl-config.mts
+++ b/src/config/kysely-ctl-config.mts
@@ -150,5 +150,13 @@ export type MigrationsBaseConfig = Omit<MigratorProps, 'db' | 'provider'> & {
 }
 
 export type SeedsBaseConfig = Omit<SeederProps, 'db' | 'provider'> & {
+	/**
+	 * `Database` interface relative-to-seed-folder path, e.g. `kysely-codegen`, `../path/to/database#MyDatabaseTypeName`.
+	 *
+	 * Default is `kysely-codegen` if it is installed, otherwise `Kysely<any>`.
+	 *
+	 * If `prisma-kysely` is installed, you can leave out the `#MyDatabaseTypeName` part, it will default to `<path>#DB`.
+	 */
+	databaseInterfacePath?: string
 	getSeedPrefix?(): string | Promise<string>
 }

--- a/src/templates/seed-type-safe-template.ts
+++ b/src/templates/seed-type-safe-template.ts
@@ -1,0 +1,7 @@
+import type { <typename> } from '<path>'
+import type { Kysely } from 'kysely'
+
+export async function seed(db: Kysely<<typename>>): Promise<void> {
+	// seed code goes here...
+	// note: this function is mandatory. you must implement this function.
+}

--- a/src/utils/version.mts
+++ b/src/utils/version.mts
@@ -6,16 +6,35 @@ import type { HasCWD } from '../config/get-cwd.mjs'
 import { getPackageManager } from './package-manager.mjs'
 import { getCTLPackageJSON, getConsumerPackageJSON } from './pkg-json.mjs'
 
-/**
- * Returns the version of the Kysely package.
- */
 export async function getKyselyInstalledVersion(
 	args: HasCWD,
+): Promise<string | null> {
+	return await getInstalledVersionFromConsumerPackageJSON(args, 'kysely')
+}
+
+export async function getKyselyCodegenInstalledVersion(
+	args: HasCWD,
+): Promise<string | null> {
+	return await getInstalledVersionFromConsumerPackageJSON(
+		args,
+		'kysely-codegen',
+	)
+}
+
+export async function getPrismaKyselyInstalledVersion(
+	args: HasCWD,
+): Promise<string | null> {
+	return await getInstalledVersionFromConsumerPackageJSON(args, 'prisma-kysely')
+}
+
+async function getInstalledVersionFromConsumerPackageJSON(
+	args: HasCWD,
+	name: string,
 ): Promise<string | null> {
 	try {
 		const pkgJSON = await getConsumerPackageJSON(args)
 
-		return getVersionFromPackageJSON('kysely', pkgJSON)
+		return getVersionFromPackageJSON(name, pkgJSON)
 	} catch (err) {
 		return null
 	}


### PR DESCRIPTION
Hey :wave:

This PR adds the ability to generate type-safe seed files.
Adds a `databaseInterfacePath` prop @ `config.seeds`.

If `kysely-codegen` is detected, it defaults to using `DB` from `kysely-codegen`, otherwise uses a non-type-safe template with `Kysely<any>`.

If a path is provided without a database name prefix (`#DBName`), and `prisma-kysely` is installed, defaults to `DB`.