### PR TITLE
loosen environment-override types, align environment value hint with c12's predefined environment names.

### DIFF
--- a/src/arguments/environment.mts
+++ b/src/arguments/environment.mts
@@ -6,6 +6,6 @@ export const EnvironmentArg = {
 		description:
 			'Apply environment-specific overrides to the configuration. See https://github.com/unjs/c12#environment-specific-configuration for more information.',
 		type: 'string',
-		valueHint: 'prod | dev | test | ...',
+		valueHint: 'production | development | test | ...',
 	},
 } satisfies ArgsDef

--- a/src/config/define-config.mts
+++ b/src/config/define-config.mts
@@ -1,4 +1,7 @@
-import { createDefineConfig } from 'c12'
+import type { C12InputConfig } from 'c12'
+import type { PartialDeep } from 'type-fest'
 import type { KyselyCTLConfig } from './kysely-ctl-config.mjs'
 
-export const defineConfig = createDefineConfig<KyselyCTLConfig>()
+export const defineConfig = (
+	input: KyselyCTLConfig & C12InputConfig<PartialDeep<KyselyCTLConfig>>,
+): KyselyCTLConfig & C12InputConfig<PartialDeep<KyselyCTLConfig>> => input

--- a/src/config/kysely-ctl-config.mts
+++ b/src/config/kysely-ctl-config.mts
@@ -134,7 +134,7 @@ type MigratorlessMigrationsConfig = MigrationsBaseConfig &
 type SeederfulSeedsConfig = Pick<SeedsBaseConfig, 'getSeedPrefix'> & {
 	provider?: never
 	seeder: Seeder
-	seedsFolder?: never
+	seedFolder?: never
 }
 
 type SeederlessSeedsConfig = SeedsBaseConfig &

--- a/tests/define-config.test-d.ts
+++ b/tests/define-config.test-d.ts
@@ -428,6 +428,22 @@ describe('defineConfig', () => {
 			})
 		})
 	})
+
+	it('environment override issue - https://github.com/kysely-org/kysely-ctl/issues/53', () => {
+		defineConfig({
+			dialect: dialect,
+			plugins: plugins,
+			migrations: {
+				migrationFolder: './src/db/migrations',
+			},
+			$development: {
+				seeds: {
+					// this type-errored before the fix
+					seedFolder: './src/db/seeds/development',
+				},
+			},
+		})
+	})
 })
 
 function init() {


### PR DESCRIPTION
closes #53.