### PR TITLE
add `allowJS` to optionally support JS files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ export default defineConfig({
   dialect, // a `Kysely` dialect instance OR the name of an underlying driver library (e.g. `'pg'`).
   dialectConfig, // optional. when `dialect` is the name of an underlying driver library, `dialectConfig` is the options passed to the Kysely dialect that matches that library.
   migrations: { // optional.
+    allowJS, // optional. controls whether `.js`, `.cjs` or `.mjs` migrations are allowed. default is `false`.
     getMigrationPrefix, // optional. a function that returns a migration prefix. affects `migrate make` command. default is `() => ${Date.now()}_`.
     migrationFolder, // optional. name of migrations folder. default is `'migrations'`.
     migrator, // optional. a `Kysely` migrator instance. default is `Kysely`'s `Migrator`.
@@ -100,6 +101,7 @@ export default defineConfig({
   },
   plugins, // optional. `Kysely` plugins list. default is `[]`.
   seeds: { // optional.
+    allowJS, // optional. controls whether `.js`, `.cjs` or `.mjs` seeds are allowed. default is `false`.
     getSeedPrefix, // optional. a function that returns a seed prefix. affects `seed make` command. default is `() => ${Date.now()}_`.
     provider, // optional. a seed provider instance. default is `kysely-ctl`'s `FileSeedProvider`.
     seeder, // optional. a seeder instance. default is `kysely-ctl`'s `Seeder`.

--- a/src/commands/init.mts
+++ b/src/commands/init.mts
@@ -7,6 +7,7 @@ import { DebugArg } from '../arguments/debug.mjs'
 import { ExtensionArg, assertExtension } from '../arguments/extension.mjs'
 import { NoOutdatedCheckArg } from '../arguments/no-outdated-notice.mjs'
 import { configFileExists, getConfig } from '../config/get-config.mjs'
+import { getTemplateExtension } from '../utils/get-template-extension.mjs'
 
 const args = {
 	...CWDArg,
@@ -28,8 +29,6 @@ export const InitCommand = {
 
 			consola.debug(context, [])
 
-			assertExtension(extension)
-
 			const config = await getConfig(args)
 
 			if (configFileExists(config)) {
@@ -37,6 +36,8 @@ export const InitCommand = {
 					`Init skipped: config file already exists at ${config.configMetadata.configFile}`,
 				)
 			}
+
+			assertExtension(extension)
 
 			const configFolderPath = join(config.cwd, '.config')
 
@@ -54,7 +55,16 @@ export const InitCommand = {
 
 			consola.debug('File path:', filePath)
 
-			await copyFile(join(__dirname, 'templates/config-template.ts'), filePath)
+			const templateExtension = await getTemplateExtension(extension)
+
+			const templatePath = join(
+				__dirname,
+				`templates/config-template.${templateExtension}`,
+			)
+
+			consola.debug('Template path:', templatePath)
+
+			await copyFile(templatePath, filePath)
 
 			consola.success(`Config file created at ${filePath}`)
 		},

--- a/src/commands/migrate/make.mts
+++ b/src/commands/migrate/make.mts
@@ -7,6 +7,7 @@ import { ExtensionArg, assertExtension } from '../../arguments/extension.mjs'
 import { createMigrationNameArg } from '../../arguments/migration-name.mjs'
 import { getConfigOrFail } from '../../config/get-config.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { getTemplateExtension } from '../../utils/get-template-extension.mjs'
 
 const args = {
 	...CommonArgs,
@@ -25,9 +26,9 @@ const BaseMakeCommand = {
 
 		consola.debug(context, [])
 
-		assertExtension(extension)
-
 		const config = await getConfigOrFail(args)
+
+		assertExtension(extension, config, 'migrations')
 
 		const migrationsFolderPath = join(
 			config.cwd,
@@ -54,7 +55,16 @@ const BaseMakeCommand = {
 
 		consola.debug('File path:', filePath)
 
-		await copyFile(join(__dirname, 'templates/migration-template.ts'), filePath)
+		const templateExtension = await getTemplateExtension(extension)
+
+		const templatePath = join(
+			__dirname,
+			`templates/migration-template.${templateExtension}`,
+		)
+
+		consola.debug('Template path:', templatePath)
+
+		await copyFile(templatePath, filePath)
 
 		consola.success(`Created migration file at ${filePath}`)
 	},

--- a/src/commands/root.mts
+++ b/src/commands/root.mts
@@ -49,13 +49,15 @@ export const RootCommand = {
 		...SeedCommand,
 	},
 	setup(context) {
-		if (context.args.debug) {
+		const { args } = context
+
+		if (args.debug) {
 			consola.level = LogLevels.debug
 		}
 
 		consola.options.formatOptions.date = false
 
-		getCWD(context.args) // ensures the CWD is set
+		getCWD(args) // ensures the CWD is set
 	},
 	async run(context) {
 		const { args } = context

--- a/src/commands/seed/make.mts
+++ b/src/commands/seed/make.mts
@@ -6,6 +6,7 @@ import { CommonArgs } from '../../arguments/common.mjs'
 import { ExtensionArg, assertExtension } from '../../arguments/extension.mjs'
 import { getConfigOrFail } from '../../config/get-config.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { getTemplateExtension } from '../../utils/get-template-extension.mjs'
 
 const args = {
 	...CommonArgs,
@@ -28,9 +29,9 @@ const BaseMakeCommand = {
 
 		consola.debug(context, [])
 
-		assertExtension(extension)
-
 		const config = await getConfigOrFail(args)
+
+		assertExtension(extension, config, 'seeds')
 
 		const seedsFolderPath = join(config.cwd, config.seeds.seedFolder)
 
@@ -54,7 +55,16 @@ const BaseMakeCommand = {
 
 		consola.debug('File path:', filePath)
 
-		await copyFile(join(__dirname, 'templates/seed-template.ts'), filePath)
+		const templateExtension = await getTemplateExtension(extension)
+
+		const templatePath = join(
+			__dirname,
+			`templates/seed-template.${templateExtension}`,
+		)
+
+		consola.debug('Template path:', templatePath)
+
+		await copyFile(templatePath, filePath)
 
 		consola.success(`Created seed file at ${filePath}`)
 	},

--- a/src/config/get-config.mts
+++ b/src/config/get-config.mts
@@ -36,11 +36,13 @@ export async function getConfig(
 		configMetadata,
 		cwd,
 		migrations: {
+			allowJS: false,
 			getMigrationPrefix: getMillisPrefix,
 			migrationFolder: 'migrations',
 			...(config?.migrations || {}),
 		},
 		seeds: {
+			allowJS: false,
 			getSeedPrefix: getMillisPrefix,
 			seedFolder: 'seeds',
 			...(config?.seeds || {}),

--- a/src/config/kysely-ctl-config.mts
+++ b/src/config/kysely-ctl-config.mts
@@ -112,6 +112,7 @@ type MigratorfulMigrationsConfig = Pick<
 	MigrationsBaseConfig,
 	'getMigrationPrefix'
 > & {
+	allowJS?: never
 	migrationFolder?: never
 	migrator: Migrator
 	provider?: never
@@ -120,11 +121,13 @@ type MigratorfulMigrationsConfig = Pick<
 type MigratorlessMigrationsConfig = MigrationsBaseConfig &
 	(
 		| {
+				allowJS?: boolean
 				migrationFolder?: string
 				migrator?: never
 				provider?: never
 		  }
 		| {
+				allowJS?: never
 				migrationFolder?: never
 				migrator?: never
 				provider: MigrationProvider
@@ -132,6 +135,7 @@ type MigratorlessMigrationsConfig = MigrationsBaseConfig &
 	)
 
 type SeederfulSeedsConfig = Pick<SeedsBaseConfig, 'getSeedPrefix'> & {
+	allowJS?: never
 	provider?: never
 	seeder: Seeder
 	seedFolder?: never
@@ -140,11 +144,13 @@ type SeederfulSeedsConfig = Pick<SeedsBaseConfig, 'getSeedPrefix'> & {
 type SeederlessSeedsConfig = SeedsBaseConfig &
 	(
 		| {
+				allowJS?: boolean
 				provider?: never
 				seeder?: never
 				seedFolder?: string
 		  }
 		| {
+				allowJS?: never
 				provider: SeedProvider
 				seeder?: never
 				seedFolder?: never
@@ -161,12 +167,14 @@ export interface ResolvedKyselyCTLConfig {
 	dialectConfig?: KyselyDialectConfig<any>
 	kysely?: Kysely<any>
 	migrations: SetRequired<MigrationsBaseConfig, 'getMigrationPrefix'> & {
+		allowJS: boolean
 		migrationFolder: string
 		migrator?: Migrator
 		provider?: MigrationProvider
 	}
 	plugins?: KyselyPlugin[]
 	seeds: SetRequired<SeedsBaseConfig, 'getSeedPrefix'> & {
+		allowJS: boolean
 		provider?: SeedProvider
 		seeder?: Seeder
 		seedFolder: string

--- a/src/kysely/get-migrator.mts
+++ b/src/kysely/get-migrator.mts
@@ -5,7 +5,8 @@ import { TSFileMigrationProvider } from './ts-file-migration-provider.mjs'
 
 export function getMigrator(config: ResolvedKyselyCTLConfig): Migrator {
 	const { kysely, migrations } = config
-	const { migrationFolder, migrator, provider, ...migratorOptions } = migrations
+	const { allowJS, migrationFolder, migrator, provider, ...migratorOptions } =
+		migrations
 
 	if (migrator) {
 		return migrator
@@ -21,6 +22,7 @@ export function getMigrator(config: ResolvedKyselyCTLConfig): Migrator {
 		provider:
 			provider ||
 			new TSFileMigrationProvider({
+				allowJS,
 				migrationFolder: join(config.cwd, migrationFolder),
 			}),
 	})

--- a/src/seeds/get-seeder.mts
+++ b/src/seeds/get-seeder.mts
@@ -5,7 +5,7 @@ import { Seeder } from './seeder.mjs'
 
 export function getSeeder(config: ResolvedKyselyCTLConfig): Seeder {
 	const { kysely, seeds } = config
-	const { seedFolder, seeder, provider, ...seederOptions } = seeds
+	const { allowJS, seedFolder, seeder, provider, ...seederOptions } = seeds
 
 	if (seeder) {
 		return seeder
@@ -23,6 +23,7 @@ export function getSeeder(config: ResolvedKyselyCTLConfig): Seeder {
 			provider:
 				provider ||
 				new FileSeedProvider({
+					allowJS,
 					seedFolder: join(config.cwd, seedFolder),
 				}),
 		})

--- a/src/templates/config-template.cjs
+++ b/src/templates/config-template.cjs
@@ -1,13 +1,13 @@
-const { 
-    DummyDriver, 
-    PostgresAdapter, 
-    PostgresIntrospector, 
-    PostgresQueryCompiler,
+const {
+	DummyDriver,
+	PostgresAdapter,
+	PostgresIntrospector,
+	PostgresQueryCompiler,
 } = require('kysely')
 const { defineConfig } = require('kysely-ctl')
 
 exports.default = defineConfig({
-    // replace me with a real dialect instance OR a dialect name + `dialectConfig` prop.
+	// replace me with a real dialect instance OR a dialect name + `dialectConfig` prop.
 	dialect: {
 		createAdapter() {
 			return new PostgresAdapter()
@@ -23,10 +23,10 @@ exports.default = defineConfig({
 		},
 	},
 	migrations: {
-	    allowJS: true,
+		allowJS: true,
 	},
 	//   plugins: [],
-    seeds: {
-        allowJS: true,
-    },
+	seeds: {
+		allowJS: true,
+	},
 })

--- a/src/templates/config-template.cjs
+++ b/src/templates/config-template.cjs
@@ -1,0 +1,32 @@
+const { 
+    DummyDriver, 
+    PostgresAdapter, 
+    PostgresIntrospector, 
+    PostgresQueryCompiler,
+} = require('kysely')
+const { defineConfig } = require('kysely-ctl')
+
+exports.default = defineConfig({
+    // replace me with a real dialect instance OR a dialect name + `dialectConfig` prop.
+	dialect: {
+		createAdapter() {
+			return new PostgresAdapter()
+		},
+		createDriver() {
+			return new DummyDriver()
+		},
+		createIntrospector(db) {
+			return new PostgresIntrospector(db)
+		},
+		createQueryCompiler() {
+			return new PostgresQueryCompiler()
+		},
+	},
+	migrations: {
+	    allowJS: true,
+	},
+	//   plugins: [],
+    seeds: {
+        allowJS: true,
+    },
+})

--- a/src/templates/config-template.mjs
+++ b/src/templates/config-template.mjs
@@ -28,5 +28,5 @@ export default defineConfig({
 	//   plugins: [],
 	seeds: {
 		allowJS: true,
-	}
+	},
 })

--- a/src/templates/config-template.mjs
+++ b/src/templates/config-template.mjs
@@ -1,0 +1,32 @@
+import {
+	DummyDriver,
+	PostgresAdapter,
+	PostgresIntrospector,
+	PostgresQueryCompiler,
+} from 'kysely'
+import { defineConfig } from 'kysely-ctl'
+
+export default defineConfig({
+	// replace me with a real dialect instance OR a dialect name + `dialectConfig` prop.
+	dialect: {
+		createAdapter() {
+			return new PostgresAdapter()
+		},
+		createDriver() {
+			return new DummyDriver()
+		},
+		createIntrospector(db) {
+			return new PostgresIntrospector(db)
+		},
+		createQueryCompiler() {
+			return new PostgresQueryCompiler()
+		},
+	},
+	migrations: {
+		allowJS: true,
+	},
+	//   plugins: [],
+	seeds: {
+		allowJS: true,
+	}
+})

--- a/src/templates/migration-template.cjs
+++ b/src/templates/migration-template.cjs
@@ -3,7 +3,7 @@
  * @returns {Promise<void>}
  */
 exports.up = async (db) => {
-   	// up migration code goes here...
+	// up migration code goes here...
 	// note: up migrations are mandatory. you must implement this function.
 	// For more info, see: https://kysely.dev/docs/migrations
 }

--- a/src/templates/migration-template.cjs
+++ b/src/templates/migration-template.cjs
@@ -1,0 +1,19 @@
+/**
+ * @param {import('kysely').Kysely<any>} db
+ * @returns {Promise<void>}
+ */
+exports.up = async (db) => {
+   	// up migration code goes here...
+	// note: up migrations are mandatory. you must implement this function.
+	// For more info, see: https://kysely.dev/docs/migrations
+}
+
+/**
+ * @param {import('kysely').Kysely<any>} db
+ * @returns {Promise<void>}
+ */
+exports.down = async (db) => {
+	// down migration code goes here...
+	// note: down migrations are optional. you can safely delete this function.
+	// For more info, see: https://kysely.dev/docs/migrations
+}

--- a/src/templates/migration-template.mjs
+++ b/src/templates/migration-template.mjs
@@ -1,0 +1,19 @@
+/**
+ * @param {import('kysely').Kysely<any>} db
+ * @returns {Promise<void>}
+ */
+export async function up(db) {
+	// up migration code goes here...
+	// note: up migrations are mandatory. you must implement this function.
+	// For more info, see: https://kysely.dev/docs/migrations
+}
+
+/**
+ * @param {import('kysely').Kysely<any>} db
+ * @returns {Promise<void>}
+ */
+export async function down(db) {
+	// down migration code goes here...
+	// note: down migrations are optional. you can safely delete this function.
+	// For more info, see: https://kysely.dev/docs/migrations
+}

--- a/src/templates/seed-template.cjs
+++ b/src/templates/seed-template.cjs
@@ -1,0 +1,8 @@
+/**
+ * @param {import('kysely').Kysely<any>} db
+ * @returns {Promise<void>}
+ */
+exports.seed = async (db) => {
+    // seed code goes here...
+	// note: this function is mandatory. you must implement this function.
+}

--- a/src/templates/seed-template.cjs
+++ b/src/templates/seed-template.cjs
@@ -3,6 +3,6 @@
  * @returns {Promise<void>}
  */
 exports.seed = async (db) => {
-    // seed code goes here...
+	// seed code goes here...
 	// note: this function is mandatory. you must implement this function.
 }

--- a/src/templates/seed-template.mjs
+++ b/src/templates/seed-template.mjs
@@ -1,0 +1,8 @@
+/**
+ * @param {import('kysely').Kysely<any>} db
+ * @returns {Promise<void>}
+ */
+export async function seed(db) {
+	// seed code goes here...
+	// note: this function is mandatory. you must implement this function.
+}

--- a/src/utils/get-file-type.mts
+++ b/src/utils/get-file-type.mts
@@ -1,0 +1,34 @@
+export function getFileType(path: string) {
+	let extension = ''
+	const lastIndex = path.length - 1
+	let i = 0
+
+	for (; i < 3; i++) {
+		const char = path.charAt(lastIndex - i)
+
+		if (char === '.') {
+			break
+		}
+
+		extension = `${char}${extension}`
+	}
+
+	if (
+		extension.length < 2 ||
+		path.charAt(lastIndex - i) !== '.' ||
+		(path.charAt(lastIndex - (i + 1)) === 'd' &&
+			path.charAt(lastIndex - (i + 2)) === '.')
+	) {
+		return 'IRRELEVANT'
+	}
+
+	if (['ts', 'mts', 'cts'].includes(extension)) {
+		return 'TS'
+	}
+
+	if (['js', 'mjs', 'cjs'].includes(extension)) {
+		return 'JS'
+	}
+
+	return 'IRRELEVANT'
+}

--- a/src/utils/get-template-extension.mts
+++ b/src/utils/get-template-extension.mts
@@ -1,0 +1,14 @@
+import type { Extension } from '../arguments/extension.mjs'
+import { getConsumerPackageJSON } from './pkg-json.mjs'
+
+export async function getTemplateExtension(
+	extension: Extension,
+): Promise<Extension> {
+	if (extension === 'js') {
+		const pkgJSON = await getConsumerPackageJSON()
+
+		return pkgJSON.type === 'module' ? 'mjs' : 'cjs'
+	}
+
+	return extension === 'cjs' || extension === 'mjs' ? extension : 'ts'
+}

--- a/src/utils/is-ts-file.mts
+++ b/src/utils/is-ts-file.mts
@@ -1,7 +1,0 @@
-export function isTSFile(path: string): boolean {
-	return (
-		(path.endsWith('.ts') && !path.endsWith('.d.ts')) ||
-		(path.endsWith('.cts') && !path.endsWith('.d.cts')) ||
-		(path.endsWith('.mts') && !path.endsWith('.d.mts'))
-	)
-}

--- a/tests/get-file-type.test.ts
+++ b/tests/get-file-type.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { getFileType } from '../src/utils/get-file-type.mjs'
+
+const TS_EXTENSIONS = ['ts', 'mts', 'cts']
+const JS_EXTENSIONS = ['js', 'mjs', 'cjs']
+const ALL_EXTENSIONS = [...TS_EXTENSIONS, ...JS_EXTENSIONS]
+
+describe('getFileType', () => {
+	it.each(TS_EXTENSIONS)('should return "TS" for name.%s file', (extension) => {
+		const result = getFileType(`file.${extension}`)
+
+		expect(result).toEqual('TS')
+	})
+
+	it.each(JS_EXTENSIONS)('should return "JS" for name.%s file', (extension) => {
+		const result = getFileType(`file.${extension}`)
+
+		expect(result).toEqual('JS')
+	})
+
+	it.each(ALL_EXTENSIONS)(
+		'should return "IRRELEVANT" for name.d.%s file',
+		(extension) => {
+			const result = getFileType(`file.d.${extension}`)
+
+			expect(result).toEqual('IRRELEVANT')
+		},
+	)
+
+	it.each(TS_EXTENSIONS)('should return "TS" for d.%s file', (extension) => {
+		const result = getFileType(`d.${extension}`)
+
+		expect(result).toEqual('TS')
+	})
+
+	it.each(JS_EXTENSIONS)('should return "JS" for d.%s file', (extension) => {
+		const result = getFileType(`d.${extension}`)
+
+		expect(result).toEqual('JS')
+	})
+
+	it('should return "IRRELEVANT" for file without extension', () => {
+		const result = getFileType('file')
+
+		expect(result).toEqual('IRRELEVANT')
+	})
+
+	it('should return "IRRELEVANT" for file with less than 2 characters extension', () => {
+		const result = getFileType('file.a')
+
+		expect(result).toEqual('IRRELEVANT')
+	})
+
+	it.each(ALL_EXTENSIONS)(
+		'should return "IRRELEVANT" for file with unrecognized .e%s extension',
+		(extension) => {
+			const result = getFileType(`file.e${extension}`)
+
+			expect(result).toEqual('IRRELEVANT')
+		},
+	)
+})


### PR DESCRIPTION
closes #74.

Hey :wave:

This PR adds `migrations.allowJS` and `seeds.allowJS` - false by default (we're a TS-first project).

When enabled, `js`, `mjs` and `cjs` are valid extensions.