### PR TITLE
fix: typo in `--help` description for `migrate:make`

### DIFF
--- a/src/arguments/migration-name.mts
+++ b/src/arguments/migration-name.mts
@@ -3,7 +3,7 @@ import type { ArgsDef } from 'citty'
 export const createMigrationNameArg = (required = false) =>
 	({
 		migration_name: {
-			description: 'Migration name to run/undo.',
+			description: 'Migration name to create.',
 			required,
 			type: 'positional',
 		},


### PR DESCRIPTION
A tiny typo–which I suspect was confusing my AI coding bot. 😅 