### PR TITLE
feat: add `--fail-on-pending` flag to `migrate:list`

### DIFF
--- a/src/commands/migrate/list.mts
+++ b/src/commands/migrate/list.mts
@@ -7,6 +7,11 @@ import { createSubcommand } from '../../utils/create-subcommand.mjs'
 
 const args = {
 	...CommonArgs,
+	'fail-on-pending': {
+		type: 'boolean',
+		default: false,
+		required: false
+	}
 } satisfies ArgsDef
 
 const BaseListCommand = {
@@ -32,6 +37,12 @@ const BaseListCommand = {
 
 		for (const migration of migrations) {
 			consola.log(`[${migration.executedAt ? '`✓`' : ' '}] ${migration.name}`)
+		}
+
+		const hasPending = migrations.some(migration => migration.executedAt === undefined);
+
+		if (context.args['fail-on-pending'] && hasPending) {
+			throw new Error('Failed due to pending migrations.');
 		}
 	},
 } satisfies CommandDef<typeof args>


### PR DESCRIPTION
i tested it against my database locally and it seems to work! i wasn't sure what the right way to fail the command was, i thought `consola.fail` would result in a non-zero exit code but it didn't so i'm just throwing an error, let me know if there's a more elegant way to do it!

Fixes https://github.com/kysely-org/kysely-ctl/issues/164