### PR TITLE
feat: Changes uses of any to unknown

### DIFF
--- a/examples/bun/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/bun/migrations/1716743937856_add_table_moshe.ts
@@ -5,10 +5,10 @@ if (Bun.env) {
 	console.log('Bun env is available')
 }
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.dropTable('moshe').execute()
 }

--- a/examples/bun/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/bun/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,9 +1,9 @@
 import type { Kysely } from 'kysely'
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').dropColumn('is_moshe').execute()
 }

--- a/examples/deno-deno-json/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/deno-deno-json/migrations/1716743937856_add_table_moshe.ts
@@ -5,10 +5,10 @@ if (Deno.env) {
 	console.log('Deno env is available')
 }
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.dropTable('moshe').execute()
 }

--- a/examples/deno-deno-json/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/deno-deno-json/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,9 +1,9 @@
 import type { Kysely } from 'kysely'
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').dropColumn('is_moshe').execute()
 }

--- a/examples/deno-no-config/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/deno-no-config/migrations/1716743937856_add_table_moshe.ts
@@ -5,10 +5,10 @@ if (Deno.env) {
 	console.log('Deno env is available')
 }
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.dropTable('moshe').execute()
 }

--- a/examples/deno-no-config/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/deno-no-config/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,9 +1,9 @@
 import type { Kysely } from 'npm:kysely@^0.27.6'
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').dropColumn('is_moshe').execute()
 }

--- a/examples/deno-package-json/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/deno-package-json/migrations/1716743937856_add_table_moshe.ts
@@ -5,10 +5,10 @@ if (Deno.env) {
 	console.log('Deno env is available')
 }
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.dropTable('moshe').execute()
 }

--- a/examples/deno-package-json/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/deno-package-json/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,9 +1,9 @@
 import type { Kysely } from 'kysely'
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').dropColumn('is_moshe').execute()
 }

--- a/examples/node-cjs/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/node-cjs/migrations/1716743937856_add_table_moshe.ts
@@ -1,9 +1,9 @@
 import type { Kysely } from 'kysely'
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.dropTable('moshe').execute()
 }

--- a/examples/node-cjs/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/node-cjs/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,9 +1,9 @@
 import type { Kysely } from 'kysely'
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').dropColumn('is_moshe').execute()
 }

--- a/examples/node-esm-top-level-await/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/node-esm-top-level-await/migrations/1716743937856_add_table_moshe.ts
@@ -3,10 +3,10 @@ import type { Kysely } from 'kysely'
 
 await setTimeout(0)
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.dropTable('moshe').execute()
 }

--- a/examples/node-esm-top-level-await/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/node-esm-top-level-await/migrations/1716746051776_add_column_is_moshe.ts
@@ -3,10 +3,10 @@ import type { Kysely } from 'kysely'
 
 await setTimeout(0)
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').dropColumn('is_moshe').execute()
 }

--- a/examples/node-esm-tsconfig-paths/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/node-esm-tsconfig-paths/migrations/1716743937856_add_table_moshe.ts
@@ -1,10 +1,10 @@
 import { MOSHE_TABLE } from '@/config/db'
 import type { Kysely } from 'kysely'
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.createTable(MOSHE_TABLE).addColumn('id', 'integer').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.dropTable(MOSHE_TABLE).execute()
 }

--- a/examples/node-esm-tsconfig-paths/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/node-esm-tsconfig-paths/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,13 +1,13 @@
 import { MOSHE_TABLE } from '@/config/db'
 import type { Kysely } from 'kysely'
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema
 		.alterTable(MOSHE_TABLE)
 		.addColumn('is_moshe', 'boolean')
 		.execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable(MOSHE_TABLE).dropColumn('is_moshe').execute()
 }

--- a/examples/node-esm/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/node-esm/migrations/1716743937856_add_table_moshe.ts
@@ -1,9 +1,9 @@
 import type { Kysely } from 'kysely'
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.dropTable('moshe').execute()
 }

--- a/examples/node-esm/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/node-esm/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,9 +1,9 @@
 import type { Kysely } from 'kysely'
 
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	await db.schema.alterTable('moshe').dropColumn('is_moshe').execute()
 }

--- a/src/config/kysely-ctl-config.mts
+++ b/src/config/kysely-ctl-config.mts
@@ -87,20 +87,17 @@ export type KyselyCTLConfig<Dialect extends KyselyDialect = KyselyDialect> =
 						seeds?: SeederlessSeedsConfig
 				  }
 				| {
-						// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
-						kysely: Kysely<any>
+						kysely: Kysely<unknown>
 						migrations: MigratorfulMigrationsConfig
 						seeds?: SeederlessSeedsConfig
 				  }
 				| {
-						// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
-						kysely: Kysely<any>
+						kysely: Kysely<unknown>
 						migrations?: MigratorlessMigrationsConfig
 						seeds: SeederfulSeedsConfig
 				  }
 				| {
-						// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
-						kysely: Kysely<any>
+						kysely: Kysely<unknown>
 						migrations?: MigratorlessMigrationsConfig
 						seeds?: SeederlessSeedsConfig
 				  }
@@ -171,8 +168,7 @@ export interface ResolvedKyselyCTLConfig {
 	dialect?: KyselyDialect
 	// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
 	dialectConfig?: KyselyDialectConfig<any>
-	// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
-	kysely?: Kysely<any>
+	kysely?: Kysely<unknown>
 	migrations: SetRequired<MigrationsBaseConfig, 'getMigrationPrefix'> & {
 		allowJS: boolean
 		migrationFolder: string

--- a/src/kysely/using-kysely.mts
+++ b/src/kysely/using-kysely.mts
@@ -4,8 +4,7 @@ import { getKysely } from './get-kysely.mjs'
 
 export async function usingKysely<T>(
 	config: ResolvedKyselyCTLConfig,
-	// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
-	callback: (kysely: Kysely<any>) => Promise<T>,
+	callback: (kysely: Kysely<unknown>) => Promise<T>,
 ): Promise<T> {
 	const kysely = await getKysely(config)
 

--- a/src/seeds/seeder.mts
+++ b/src/seeds/seeder.mts
@@ -52,8 +52,7 @@ export class Seeder {
 }
 
 export interface Seed {
-	// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
-	seed(db: Kysely<any>): Promise<void>
+	seed(db: Kysely<unknown>): Promise<void>
 }
 
 export interface SeedProvider {
@@ -61,8 +60,7 @@ export interface SeedProvider {
 }
 
 export interface SeederProps {
-	// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
-	db: Kysely<any>
+	db: Kysely<unknown>
 	provider: SeedProvider
 }
 

--- a/src/templates/migration-template.cjs
+++ b/src/templates/migration-template.cjs
@@ -1,5 +1,5 @@
 /**
- * @param {import('kysely').Kysely<any>} db `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+ * @param {import('kysely').Kysely<unknown>}
  * @returns {Promise<void>}
  */
 exports.up = async (db) => {
@@ -9,7 +9,7 @@ exports.up = async (db) => {
 }
 
 /**
- * @param {import('kysely').Kysely<any>} db `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+ * @param {import('kysely').Kysely<unknown>}
  * @returns {Promise<void>}
  */
 exports.down = async (db) => {

--- a/src/templates/migration-template.mjs
+++ b/src/templates/migration-template.mjs
@@ -1,5 +1,5 @@
 /**
- * @param {import('kysely').Kysely<any>} db `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+ * @param {import('kysely').Kysely<unknown>}
  * @returns {Promise<void>}
  */
 export async function up(db) {
@@ -9,7 +9,7 @@ export async function up(db) {
 }
 
 /**
- * @param {import('kysely').Kysely<any>} db `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+ * @param {import('kysely').Kysely<unknown>}
  * @returns {Promise<void>}
  */
 export async function down(db) {

--- a/src/templates/migration-template.ts
+++ b/src/templates/migration-template.ts
@@ -1,14 +1,12 @@
 import type { Kysely } from 'kysely'
 
-// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
-export async function up(db: Kysely<any>): Promise<void> {
+export async function up(db: Kysely<unknown>): Promise<void> {
 	// up migration code goes here...
 	// note: up migrations are mandatory. you must implement this function.
 	// For more info, see: https://kysely.dev/docs/migrations
 }
 
-// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
-export async function down(db: Kysely<any>): Promise<void> {
+export async function down(db: Kysely<unknown>): Promise<void> {
 	// down migration code goes here...
 	// note: down migrations are optional. you can safely delete this function.
 	// For more info, see: https://kysely.dev/docs/migrations

--- a/src/templates/seed-template.cjs
+++ b/src/templates/seed-template.cjs
@@ -1,5 +1,5 @@
 /**
- * @param {import('kysely').Kysely<any>} db replace `any` with your database type
+ * @param {import('kysely').Kysely<unknown>} db replace `unknown` with your database type
  * @returns {Promise<void>}
  */
 exports.seed = async (db) => {

--- a/src/templates/seed-template.mjs
+++ b/src/templates/seed-template.mjs
@@ -1,5 +1,5 @@
 /**
- * @param {import('kysely').Kysely<any>} db replace `any` with your database type
+ * @param {import('kysely').Kysely<unknown>} db replace `unknown` with your database type
  * @returns {Promise<void>}
  */
 export async function seed(db) {

--- a/src/templates/seed-template.ts
+++ b/src/templates/seed-template.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from 'kysely'
 
-// replace `any` with your database interface.
-export async function seed(db: Kysely<any>): Promise<void> {
+// replace `unknown` with your database interface.
+export async function seed(db: Kysely<unknown>): Promise<void> {
 	// seed code goes here...
 	// note: this function is mandatory. you must implement this function.
 }


### PR DESCRIPTION
Instead of using `any` in places where there's no database interface, we can use `unknown`. Most folks/linting setups are fine with `unknown`

> unknown is the type-safe counterpart of any

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#new-unknown-top-type