### PR TITLE
feat: allow kysely@0.28.0 in peer dependencies

### DIFF
--- a/examples/bun/bun.lock
+++ b/examples/bun/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "bun-example",
       "dependencies": {
-        "kysely": "^0.27.6",
+        "kysely": "^0.28.0",
         "kysely-bun-sqlite": "^0.3.2",
       },
       "devDependencies": {
@@ -25,7 +25,7 @@
 
     "bun-types": ["bun-types@1.2.5", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-3oO6LVGGRRKI4kHINx5PIdIgnLRb7l/SprhzqXapmoYkFl5m4j6EvALvbDVuuBFaamB46Ap6HCUxIXNLCGy+tg=="],
 
-    "kysely": ["kysely@0.27.6", "", {}, "sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ=="],
+    "kysely": ["kysely@0.28.0", "", {}, "sha512-hq8VcLy57Ww7oPTTVEOrT9ml+g8ehbbmEUkHmW4Xtubu+NHdKZi6SH6egmD4cjDhn3b/0s0h/6AjdPayOTJhNw=="],
 
     "kysely-bun-sqlite": ["kysely-bun-sqlite@0.3.2", "", { "dependencies": { "bun-types": "^1.0.25" }, "peerDependencies": { "kysely": "^0.27.2" } }, "sha512-YucMcOGGxNCmlAnkvNfTKZX6Bk1sYsuVVXlQN/5ZUgerlq/J9/EuR3aMOOZ25ASLM7oMglSxfeQxkiw0+hrEOQ=="],
 

--- a/examples/bun/package.json
+++ b/examples/bun/package.json
@@ -10,7 +10,7 @@
 		"typescript": "^5.8.2"
 	},
 	"dependencies": {
-		"kysely": "^0.27.6",
+		"kysely": "^0.28.0",
 		"kysely-bun-sqlite": "^0.3.2"
 	}
 }

--- a/examples/deno-deno-json/deno.json
+++ b/examples/deno-deno-json/deno.json
@@ -5,7 +5,7 @@
 	"imports": {
 		"@jsr/db__sqlite": "npm:@jsr/db__sqlite@^0.12.0",
 		"@jsr/soapbox__kysely-deno-sqlite": "npm:@jsr/soapbox__kysely-deno-sqlite@^2.2.0",
-		"kysely": "npm:kysely@^0.27.6",
+		"kysely": "npm:kysely@^0.28.0",
 		"kysely-ctl": "npm:kysely-ctl@^0.12.1"
 	}
 }

--- a/examples/deno-deno-json/deno.lock
+++ b/examples/deno-deno-json/deno.lock
@@ -4,9 +4,9 @@
     "npm:@jsr/db__sqlite@0.12": "0.12.0",
     "npm:@jsr/soapbox__kysely-deno-sqlite@^2.2.0": "2.2.0",
     "npm:kysely-ctl@~0.12.1": "0.12.1_kysely@0.27.5",
+    "npm:kysely@0.28": "0.28.0",
     "npm:kysely@~0.27.2": "0.27.5",
-    "npm:kysely@~0.27.5": "0.27.5",
-    "npm:kysely@~0.27.6": "0.27.6"
+    "npm:kysely@~0.27.5": "0.27.5"
   },
   "npm": {
     "@jsr/db__sqlite@0.12.0": {
@@ -160,8 +160,8 @@
     "kysely@0.27.5": {
       "integrity": "sha512-s7hZHcQeSNKpzCkHRm8yA+0JPLjncSWnjb+2TIElwS2JAqYr+Kv3Ess+9KFfJS0C1xcQ1i9NkNHpWwCYpHMWsA=="
     },
-    "kysely@0.27.6": {
-      "integrity": "sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ=="
+    "kysely@0.28.0": {
+      "integrity": "sha512-hq8VcLy57Ww7oPTTVEOrT9ml+g8ehbbmEUkHmW4Xtubu+NHdKZi6SH6egmD4cjDhn3b/0s0h/6AjdPayOTJhNw=="
     },
     "minipass@3.3.6": {
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
@@ -269,7 +269,7 @@
       "npm:@jsr/db__sqlite@0.12",
       "npm:@jsr/soapbox__kysely-deno-sqlite@^2.2.0",
       "npm:kysely-ctl@~0.12.1",
-      "npm:kysely@~0.27.6"
+      "npm:kysely@0.28"
     ]
   }
 }

--- a/examples/deno-no-config/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/deno-no-config/migrations/1716743937856_add_table_moshe.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from 'npm:kysely@^0.27.6'
+import type { Kysely } from 'npm:kysely@^0.28.0'
 
 if (Deno.env) {
 	// biome-ignore lint/suspicious/noConsole: console.log is fine here

--- a/examples/deno-no-config/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/deno-no-config/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from 'npm:kysely@^0.27.6'
+import type { Kysely } from 'npm:kysely@^0.28.0'
 
 export async function up(db: Kysely<any>): Promise<void> {
 	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()

--- a/examples/deno-package-json/deno.lock
+++ b/examples/deno-package-json/deno.lock
@@ -4,9 +4,9 @@
     "npm:@jsr/db__sqlite@0.12": "0.12.0",
     "npm:@jsr/soapbox__kysely-deno-sqlite@^2.2.0": "2.2.0",
     "npm:kysely-ctl@~0.12.1": "0.12.1_kysely@0.27.5",
+    "npm:kysely@0.28": "0.28.0",
     "npm:kysely@~0.27.2": "0.27.5",
-    "npm:kysely@~0.27.5": "0.27.5",
-    "npm:kysely@~0.27.6": "0.27.6"
+    "npm:kysely@~0.27.5": "0.27.5"
   },
   "npm": {
     "@jsr/db__sqlite@0.12.0": {
@@ -160,8 +160,8 @@
     "kysely@0.27.5": {
       "integrity": "sha512-s7hZHcQeSNKpzCkHRm8yA+0JPLjncSWnjb+2TIElwS2JAqYr+Kv3Ess+9KFfJS0C1xcQ1i9NkNHpWwCYpHMWsA=="
     },
-    "kysely@0.27.6": {
-      "integrity": "sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ=="
+    "kysely@0.28.0": {
+      "integrity": "sha512-hq8VcLy57Ww7oPTTVEOrT9ml+g8ehbbmEUkHmW4Xtubu+NHdKZi6SH6egmD4cjDhn3b/0s0h/6AjdPayOTJhNw=="
     },
     "minipass@3.3.6": {
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
@@ -270,7 +270,7 @@
         "npm:@jsr/db__sqlite@0.12",
         "npm:@jsr/soapbox__kysely-deno-sqlite@^2.2.0",
         "npm:kysely-ctl@~0.12.1",
-        "npm:kysely@~0.27.6"
+        "npm:kysely@0.28"
       ]
     }
   }

--- a/examples/deno-package-json/package.json
+++ b/examples/deno-package-json/package.json
@@ -9,6 +9,6 @@
 	"dependencies": {
 		"@jsr/db__sqlite": "^0.12.0",
 		"@jsr/soapbox__kysely-deno-sqlite": "^2.2.0",
-		"kysely": "^0.27.6"
+		"kysely": "^0.28.0"
 	}
 }

--- a/examples/node-cjs/package.json
+++ b/examples/node-cjs/package.json
@@ -7,7 +7,7 @@
 	},
 	"dependencies": {
 		"better-sqlite3": "^11.9.1",
-		"kysely": "^0.27.6"
+		"kysely": "^0.28.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/examples/node-cjs/pnpm-lock.yaml
+++ b/examples/node-cjs/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.9.1
         version: 11.9.1
       kysely:
-        specifier: ^0.27.6
-        version: 0.27.6
+        specifier: ^0.28.0
+        version: 0.28.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.12
@@ -85,9 +85,9 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  kysely@0.27.6:
-    resolution: {integrity: sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==}
-    engines: {node: '>=14.0.0'}
+  kysely@0.28.0:
+    resolution: {integrity: sha512-hq8VcLy57Ww7oPTTVEOrT9ml+g8ehbbmEUkHmW4Xtubu+NHdKZi6SH6egmD4cjDhn3b/0s0h/6AjdPayOTJhNw==}
+    engines: {node: '>=18.0.0'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -225,7 +225,7 @@ snapshots:
 
   ini@1.3.8: {}
 
-  kysely@0.27.6: {}
+  kysely@0.28.0: {}
 
   mimic-response@3.1.0: {}
 

--- a/examples/node-esm-top-level-await/package.json
+++ b/examples/node-esm-top-level-await/package.json
@@ -7,7 +7,7 @@
 	},
 	"dependencies": {
 		"better-sqlite3": "^11.9.1",
-		"kysely": "^0.27.6"
+		"kysely": "^0.28.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/examples/node-esm-top-level-await/pnpm-lock.yaml
+++ b/examples/node-esm-top-level-await/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.9.1
         version: 11.9.1
       kysely:
-        specifier: ^0.27.6
-        version: 0.27.6
+        specifier: ^0.28.0
+        version: 0.28.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.12
@@ -85,9 +85,9 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  kysely@0.27.6:
-    resolution: {integrity: sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==}
-    engines: {node: '>=14.0.0'}
+  kysely@0.28.0:
+    resolution: {integrity: sha512-hq8VcLy57Ww7oPTTVEOrT9ml+g8ehbbmEUkHmW4Xtubu+NHdKZi6SH6egmD4cjDhn3b/0s0h/6AjdPayOTJhNw==}
+    engines: {node: '>=18.0.0'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -225,7 +225,7 @@ snapshots:
 
   ini@1.3.8: {}
 
-  kysely@0.27.6: {}
+  kysely@0.28.0: {}
 
   mimic-response@3.1.0: {}
 

--- a/examples/node-esm-tsconfig-paths/package.json
+++ b/examples/node-esm-tsconfig-paths/package.json
@@ -7,7 +7,7 @@
 	},
 	"dependencies": {
 		"better-sqlite3": "^11.8.1",
-		"kysely": "^0.27.6"
+		"kysely": "^0.28.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/examples/node-esm-tsconfig-paths/pnpm-lock.yaml
+++ b/examples/node-esm-tsconfig-paths/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.8.1
         version: 11.8.1
       kysely:
-        specifier: ^0.27.6
-        version: 0.27.6
+        specifier: ^0.28.0
+        version: 0.28.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.12
@@ -85,9 +85,9 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  kysely@0.27.6:
-    resolution: {integrity: sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==}
-    engines: {node: '>=14.0.0'}
+  kysely@0.28.0:
+    resolution: {integrity: sha512-hq8VcLy57Ww7oPTTVEOrT9ml+g8ehbbmEUkHmW4Xtubu+NHdKZi6SH6egmD4cjDhn3b/0s0h/6AjdPayOTJhNw==}
+    engines: {node: '>=18.0.0'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -225,7 +225,7 @@ snapshots:
 
   ini@1.3.8: {}
 
-  kysely@0.27.6: {}
+  kysely@0.28.0: {}
 
   mimic-response@3.1.0: {}
 

--- a/examples/node-esm/package.json
+++ b/examples/node-esm/package.json
@@ -7,7 +7,7 @@
 	},
 	"dependencies": {
 		"better-sqlite3": "^11.9.1",
-		"kysely": "^0.27.6"
+		"kysely": "^0.28.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/examples/node-esm/pnpm-lock.yaml
+++ b/examples/node-esm/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.9.1
         version: 11.9.1
       kysely:
-        specifier: ^0.27.6
-        version: 0.27.6
+        specifier: ^0.28.0
+        version: 0.28.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.12
@@ -85,9 +85,9 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  kysely@0.27.6:
-    resolution: {integrity: sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==}
-    engines: {node: '>=14.0.0'}
+  kysely@0.28.0:
+    resolution: {integrity: sha512-hq8VcLy57Ww7oPTTVEOrT9ml+g8ehbbmEUkHmW4Xtubu+NHdKZi6SH6egmD4cjDhn3b/0s0h/6AjdPayOTJhNw==}
+    engines: {node: '>=18.0.0'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -225,7 +225,7 @@ snapshots:
 
   ini@1.3.8: {}
 
-  kysely@0.27.6: {}
+  kysely@0.28.0: {}
 
   mimic-response@3.1.0: {}
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"std-env": "^3.8.0"
 	},
 	"peerDependencies": {
-		"kysely": ">=0.18.1 <0.28.0",
+		"kysely": ">=0.18.1 <0.29.0",
 		"kysely-postgres-js": "^2"
 	},
 	"peerDependenciesMeta": {
@@ -65,7 +65,7 @@
 		"@types/better-sqlite3": "^7.6.12",
 		"@types/node": "^22.13.11",
 		"better-sqlite3": "^11.9.1",
-		"kysely": "^0.27.6",
+		"kysely": "^0.28.0",
 		"kysely-postgres-js": "^2.0.0",
 		"pkg-pr-new": "^0.0.41",
 		"postgres": "^3.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,11 +58,11 @@ importers:
         specifier: ^11.9.1
         version: 11.9.1
       kysely:
-        specifier: ^0.27.6
-        version: 0.27.6
+        specifier: ^0.28.0
+        version: 0.28.0
       kysely-postgres-js:
         specifier: ^2.0.0
-        version: 2.0.0(kysely@0.27.6)(postgres@3.4.5)
+        version: 2.0.0(kysely@0.28.0)(postgres@3.4.5)
       pkg-pr-new:
         specifier: ^0.0.41
         version: 0.0.41
@@ -1246,9 +1246,9 @@ packages:
       kysely: '>= 0.24.0 < 1'
       postgres: '>= 3.4.0 < 4'
 
-  kysely@0.27.6:
-    resolution: {integrity: sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==}
-    engines: {node: '>=14.0.0'}
+  kysely@0.28.0:
+    resolution: {integrity: sha512-hq8VcLy57Ww7oPTTVEOrT9ml+g8ehbbmEUkHmW4Xtubu+NHdKZi6SH6egmD4cjDhn3b/0s0h/6AjdPayOTJhNw==}
+    engines: {node: '>=18.0.0'}
 
   lilconfig@3.1.2:
     resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
@@ -2849,12 +2849,12 @@ snapshots:
       jsonparse: 1.3.1
       through2: 4.0.2
 
-  kysely-postgres-js@2.0.0(kysely@0.27.6)(postgres@3.4.5):
+  kysely-postgres-js@2.0.0(kysely@0.28.0)(postgres@3.4.5):
     dependencies:
-      kysely: 0.27.6
+      kysely: 0.28.0
       postgres: 3.4.5
 
-  kysely@0.27.6: {}
+  kysely@0.28.0: {}
 
   lilconfig@3.1.2: {}
 


### PR DESCRIPTION
Congrats on the Kysely 0.28.0 release!

I am using Kysely with kysely-ctl, but I am now blocked to upgrade it to 0.28.0 as kysely-ctl don't allow kysely@0.28.0 or later. It seems no breaking changes will affect kysely-ctl, so we can just allow the new version in package.json, I believe.

I bumped the version requirement to `<0.29.0`, and updated all lock files.