### PR TITLE
feat(config): `migrations.migrator` and `seeds.seeder` are now callbacks, to promote using same `Kysely` instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ folder. Run `kysely init` in your terminal to create one.
 import { defineConfig } from "kysely-ctl";
 
 export default defineConfig({
-  destroyOnExit, // optional. dictates whether the (resolved) `kysely` instance should be destroyed when a command is finished executing. applicable only when `kysely` or a `dialect` instances are passed. default is `true`.
+  destroyOnExit, // optional. dictates whether the (resolved) `kysely` instance should be destroyed when a command is finished executing. default is `true`.
   dialect, // a `Kysely` dialect instance OR the name of an underlying driver library (e.g. `'pg'`).
   dialectConfig, // optional. when `dialect` is the name of an underlying driver library, `dialectConfig` is the options passed to the Kysely dialect that matches that library.
   migrations: { // optional.

--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ folder. Run `kysely init` in your terminal to create one.
 import { defineConfig } from "kysely-ctl";
 
 export default defineConfig({
+  destroyOnExit, // optional. dictates whether the (resolved) `kysely` instance should be destroyed when a command is finished executing. applicable only when `kysely` or a `dialect` instances are passed. default is `true`.
   dialect, // a `Kysely` dialect instance OR the name of an underlying driver library (e.g. `'pg'`).
   dialectConfig, // optional. when `dialect` is the name of an underlying driver library, `dialectConfig` is the options passed to the Kysely dialect that matches that library.
   migrations: { // optional.
     allowJS, // optional. controls whether `.js`, `.cjs` or `.mjs` migrations are allowed. default is `false`.
     getMigrationPrefix, // optional. a function that returns a migration prefix. affects `migrate make` command. default is `() => ${Date.now()}_`.
     migrationFolder, // optional. name of migrations folder. default is `'migrations'`.
-    migrator, // optional. a `Kysely` migrator instance. default is `Kysely`'s `Migrator`.
+    migrator, // optional. a `Kysely` migrator instance factory of shape `(db: Kysely<any>) => Migrator | Promise<Migrator>`. default is `Kysely`'s `Migrator`.
     provider, // optional. a `Kysely` migration provider instance. default is `kysely-ctl`'s `TSFileMigrationProvider`.
   },
   plugins, // optional. `Kysely` plugins list. default is `[]`.
@@ -72,7 +73,7 @@ export default defineConfig({
     allowJS, // optional. controls whether `.js`, `.cjs` or `.mjs` seeds are allowed. default is `false`.
     getSeedPrefix, // optional. a function that returns a seed prefix. affects `seed make` command. default is `() => ${Date.now()}_`.
     provider, // optional. a seed provider instance. default is `kysely-ctl`'s `FileSeedProvider`.
-    seeder, // optional. a seeder instance. default is `kysely-ctl`'s `Seeder`.
+    seeder, // optional. a seeder instance factory of shape `(db: Kysely<any>) => Seeder | Promise<Seeder>`. default is `kysely-ctl`'s `Seeder`.
     seedFolder, // optional. name of seeds folder. default is `'seeds'`.
   }
 });
@@ -85,6 +86,7 @@ import { defineConfig } from "kysely-ctl";
 import { kysely } from 'path/to/kysely/instance';
 
 export default defineConfig({
+  destroyOnExit, // optional. dictates whether the `kysely` instance should be destroyed when a command is finished executing. default is `true`.
   // ...
   kysely,
   // ...

--- a/examples/node-esm-tsconfig-paths/src/kysely.ts
+++ b/examples/node-esm-tsconfig-paths/src/kysely.ts
@@ -3,7 +3,8 @@ import { Kysely, SqliteDialect } from 'kysely'
 
 import { DB_PATH } from '@/config/db'
 
-export default new Kysely({
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export default new Kysely<any>({
 	dialect: new SqliteDialect({
 		database: database(DB_PATH),
 	}),

--- a/src/config/kysely-ctl-config.mts
+++ b/src/config/kysely-ctl-config.mts
@@ -142,7 +142,7 @@ export interface ResolvedKyselyCTLConfig {
 	migrations: SetRequired<MigrationsBaseConfig, 'getMigrationPrefix'> & {
 		allowJS: boolean
 		migrationFolder: string
-		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+		// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
 		migrator?(db: Kysely<any>): Migrator | Promise<Migrator>
 		provider?: MigrationProvider
 	}
@@ -150,7 +150,7 @@ export interface ResolvedKyselyCTLConfig {
 	seeds: SetRequired<SeedsBaseConfig, 'getSeedPrefix'> & {
 		allowJS: boolean
 		provider?: SeedProvider
-		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+		// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
 		seeder?(db: Kysely<any>): Seeder | Promise<Seeder>
 		seedFolder: string
 	}

--- a/src/config/kysely-ctl-config.mts
+++ b/src/config/kysely-ctl-config.mts
@@ -45,71 +45,34 @@ export type KyselyDialectConfig<Dialect extends KyselyDialect> =
 
 export type KyselyCTLConfig<Dialect extends KyselyDialect = KyselyDialect> =
 	Dialect extends ResolvableKyselyDialect
-		?
-				| {
-						dialect: Dialect
-						dialectConfig: KyselyDialectConfig<Dialect>
-						migrations: MigratorfulMigrationsConfig
-						plugins?: KyselyPlugin[]
-						seeds?: SeederlessSeedsConfig
-				  }
-				| {
-						dialect: Dialect
-						dialectConfig: KyselyDialectConfig<Dialect>
-						migrations?: MigratorlessMigrationsConfig
-						plugins?: KyselyPlugin[]
-						seeds: SeederfulSeedsConfig
-				  }
-				| {
-						dialect: Dialect
-						dialectConfig: KyselyDialectConfig<Dialect>
-						migrations?: MigratorlessMigrationsConfig
-						plugins?: KyselyPlugin[]
-						seeds?: SeederlessSeedsConfig
-				  }
+		? {
+				destroyOnExit?: never
+				dialect: Dialect
+				dialectConfig: KyselyDialectConfig<Dialect>
+				kysely?: never
+				migrations?: MigratorlessMigrationsConfig | MigratorfulMigrationsConfig
+				plugins?: KyselyPlugin[]
+				seeds?: SeederlessSeedsConfig | SeederfulSeedsConfig
+			}
 		:
 				| {
+						destroyOnExit?: boolean
 						dialect: KyselyDialectInstance
-						migrations: MigratorfulMigrationsConfig
+						dialectConfig?: never
+						migrations?:
+							| MigratorlessMigrationsConfig
+							| MigratorfulMigrationsConfig
 						plugins?: KyselyPlugin[]
-						seeds?: SeederlessSeedsConfig
+						seeds?: SeederlessSeedsConfig | SeederfulSeedsConfig
 				  }
 				| {
-						dialect: KyselyDialectInstance
-						migrations?: MigratorlessMigrationsConfig
-						plugins?: KyselyPlugin[]
-						seeds: SeederfulSeedsConfig
-				  }
-				| {
-						dialect: KyselyDialectInstance
-						migrations?: MigratorlessMigrationsConfig
-						plugins?: KyselyPlugin[]
-						seeds?: SeederlessSeedsConfig
-				  }
-				| {
+						destroyOnExit?: boolean
 						// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
 						kysely: Kysely<any>
-						migrations: MigratorfulMigrationsConfig
-						seeds?: SeederlessSeedsConfig
-				  }
-				| {
-						// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
-						kysely: Kysely<any>
-						migrations?: MigratorlessMigrationsConfig
-						seeds: SeederfulSeedsConfig
-				  }
-				| {
-						// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
-						kysely: Kysely<any>
-						migrations?: MigratorlessMigrationsConfig
-						seeds?: SeederlessSeedsConfig
-				  }
-				| {
-						dialect?: never
-						kysely?: never
-						migrations: MigratorfulMigrationsConfig
-						plugins?: never
-						seeds: SeederfulSeedsConfig
+						migrations?:
+							| MigratorlessMigrationsConfig
+							| MigratorfulMigrationsConfig
+						seeds?: SeederlessSeedsConfig | SeederfulSeedsConfig
 				  }
 
 type MigratorfulMigrationsConfig = Pick<
@@ -118,7 +81,8 @@ type MigratorfulMigrationsConfig = Pick<
 > & {
 	allowJS?: never
 	migrationFolder?: never
-	migrator: Migrator
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	migrator(this: void, db: Kysely<any>): Migrator | Promise<Migrator>
 	provider?: never
 }
 
@@ -141,7 +105,8 @@ type MigratorlessMigrationsConfig = MigrationsBaseConfig &
 type SeederfulSeedsConfig = Pick<SeedsBaseConfig, 'getSeedPrefix'> & {
 	allowJS?: never
 	provider?: never
-	seeder: Seeder
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	seeder(db: Kysely<any>): Seeder | Promise<Seeder>
 	seedFolder?: never
 }
 
@@ -168,6 +133,7 @@ export interface ResolvedKyselyCTLConfig {
 		'config'
 	>
 	cwd: string
+	destroyOnExit?: boolean
 	dialect?: KyselyDialect
 	// biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
 	dialectConfig?: KyselyDialectConfig<any>
@@ -176,14 +142,16 @@ export interface ResolvedKyselyCTLConfig {
 	migrations: SetRequired<MigrationsBaseConfig, 'getMigrationPrefix'> & {
 		allowJS: boolean
 		migrationFolder: string
-		migrator?: Migrator
+		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+		migrator?(db: Kysely<any>): Migrator | Promise<Migrator>
 		provider?: MigrationProvider
 	}
 	plugins?: KyselyPlugin[]
 	seeds: SetRequired<SeedsBaseConfig, 'getSeedPrefix'> & {
 		allowJS: boolean
 		provider?: SeedProvider
-		seeder?: Seeder
+		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+		seeder?(db: Kysely<any>): Seeder | Promise<Seeder>
 		seedFolder: string
 	}
 }

--- a/src/config/kysely-ctl-config.mts
+++ b/src/config/kysely-ctl-config.mts
@@ -46,7 +46,7 @@ export type KyselyDialectConfig<Dialect extends KyselyDialect> =
 export type KyselyCTLConfig<Dialect extends KyselyDialect = KyselyDialect> =
 	Dialect extends ResolvableKyselyDialect
 		? {
-				destroyOnExit?: never
+				destroyOnExit?: boolean
 				dialect: Dialect
 				dialectConfig: KyselyDialectConfig<Dialect>
 				kysely?: never

--- a/src/kysely/get-migrator.mts
+++ b/src/kysely/get-migrator.mts
@@ -1,19 +1,18 @@
 import { Migrator } from 'kysely'
 import { join } from 'pathe'
+import type { SetRequired } from 'type-fest'
 import type { ResolvedKyselyCTLConfig } from '../config/kysely-ctl-config.mjs'
 import { TSFileMigrationProvider } from './ts-file-migration-provider.mjs'
 
-export function getMigrator(config: ResolvedKyselyCTLConfig): Migrator {
+export async function getMigrator(
+	config: SetRequired<ResolvedKyselyCTLConfig, 'kysely'>,
+): Promise<Migrator> {
 	const { args, kysely, migrations } = config
 	const { allowJS, migrationFolder, migrator, provider, ...migratorOptions } =
 		migrations
 
 	if (migrator) {
-		return migrator
-	}
-
-	if (!kysely) {
-		throw new Error('kysely instance is required to create a migrator')
+		return await migrator(kysely)
 	}
 
 	return new Migrator({

--- a/src/kysely/using-kysely.mts
+++ b/src/kysely/using-kysely.mts
@@ -12,6 +12,8 @@ export async function usingKysely<T>(
 	try {
 		return await callback(kysely)
 	} finally {
-		await kysely.destroy()
+		if (config.destroyOnExit !== false || typeof config.dialect === 'string') {
+			await kysely.destroy()
+		}
 	}
 }

--- a/src/kysely/using-kysely.mts
+++ b/src/kysely/using-kysely.mts
@@ -12,7 +12,7 @@ export async function usingKysely<T>(
 	try {
 		return await callback(kysely)
 	} finally {
-		if (config.destroyOnExit !== false || typeof config.dialect === 'string') {
+		if (config.destroyOnExit !== false) {
 			await kysely.destroy()
 		}
 	}

--- a/src/kysely/using-migrator.mts
+++ b/src/kysely/using-migrator.mts
@@ -10,7 +10,7 @@ export async function usingMigrator<T>(
 	const config = await getConfigOrFail(args)
 
 	return await usingKysely(config, async (kysely) => {
-		const migrator = getMigrator({ ...config, kysely })
+		const migrator = await getMigrator({ ...config, kysely })
 
 		return await callback(migrator)
 	})

--- a/src/seeds/get-seeder.mts
+++ b/src/seeds/get-seeder.mts
@@ -1,35 +1,31 @@
 import { join } from 'pathe'
+import type { SetRequired } from 'type-fest'
 import type { ResolvedKyselyCTLConfig } from '../config/kysely-ctl-config.mjs'
 import { FileSeedProvider } from './file-seed-provider.mjs'
 import { Seeder } from './seeder.mjs'
 
-export function getSeeder(config: ResolvedKyselyCTLConfig): Seeder {
+export async function getSeeder(
+	config: SetRequired<ResolvedKyselyCTLConfig, 'kysely'>,
+): Promise<Seeder> {
 	const { args, kysely, seeds } = config
 	const { allowJS, seedFolder, seeder, provider, ...seederOptions } = seeds
 
 	if (seeder) {
-		return seeder
+		return await seeder(kysely)
 	}
 
-	if (!kysely) {
-		throw new Error('Kysely instance is required to create a Seeder')
-	}
-
-	return (
-		seeder ||
-		new Seeder({
-			...seederOptions,
-			db: kysely,
-			provider:
-				provider ||
-				new FileSeedProvider({
-					allowJS,
-					debug: args.debug,
-					filesystemCaching: args['filesystem-caching'],
-					experimentalResolveTSConfigPaths:
-						args['experimental-resolve-tsconfig-paths'],
-					seedFolder: join(config.cwd, seedFolder),
-				}),
-		})
-	)
+	return new Seeder({
+		...seederOptions,
+		db: kysely,
+		provider:
+			provider ||
+			new FileSeedProvider({
+				allowJS,
+				debug: args.debug,
+				filesystemCaching: args['filesystem-caching'],
+				experimentalResolveTSConfigPaths:
+					args['experimental-resolve-tsconfig-paths'],
+				seedFolder: join(config.cwd, seedFolder),
+			}),
+	})
 }

--- a/src/seeds/using-seeder.mts
+++ b/src/seeds/using-seeder.mts
@@ -9,14 +9,8 @@ export async function usingSeeder<T>(
 ): Promise<T> {
 	const config = await getConfigOrFail(args)
 
-	const { seeder } = config.seeds
-
-	if (seeder) {
-		return await callback(seeder)
-	}
-
 	return await usingKysely(config, async (kysely) => {
-		const seeder = getSeeder({ ...config, kysely })
+		const seeder = await getSeeder({ ...config, kysely })
 
 		return await callback(seeder)
 	})

--- a/tests/define-config.test-d.ts
+++ b/tests/define-config.test-d.ts
@@ -441,15 +441,13 @@ describe('defineConfig', () => {
 			})
 		})
 
-		it('should type-error when also passing `destroyOnExit`', () => {
-			// @ts-expect-error
+		it('should not type-error when also passing `destroyOnExit`', () => {
 			defineConfig({
 				dialect: 'better-sqlite3',
 				dialectConfig,
 				destroyOnExit: true,
 			})
 
-			// @ts-expect-error
 			defineConfig({
 				dialect: 'better-sqlite3',
 				dialectConfig,

--- a/tests/define-config.test-d.ts
+++ b/tests/define-config.test-d.ts
@@ -31,15 +31,15 @@ describe('defineConfig', () => {
 	} = init()
 
 	describe('when passing migrator & seeder instances', () => {
-		it('should not type-error', () => {
+		it('should type-error when not passing dialect or Kysely instance', () => {
+			// @ts-expect-error
 			defineConfig({
 				migrations: { migrator },
 				seeds: { seeder },
 			})
 		})
 
-		it('should type-error when also passing a Kysely instance', () => {
-			// @ts-expect-error
+		it('should not type-error when also passing a Kysely instance', () => {
 			defineConfig({
 				kysely,
 				migrations: { migrator },
@@ -47,8 +47,7 @@ describe('defineConfig', () => {
 			})
 		})
 
-		it('should type-error when also passing a dialect instance', () => {
-			// @ts-expect-error
+		it('should not type-error when also passing a dialect instance', () => {
 			defineConfig({
 				dialect,
 				migrations: { migrator },
@@ -56,21 +55,11 @@ describe('defineConfig', () => {
 			})
 		})
 
-		it('should type-error when also passing a dialect name', () => {
-			// @ts-expect-error
+		it('should not type-error when also passing a dialect name', () => {
 			defineConfig({
 				dialect: 'better-sqlite3',
 				dialectConfig,
 				migrations: { migrator },
-				seeds: { seeder },
-			})
-		})
-
-		it('should type-error when also passing plugins', () => {
-			// @ts-expect-error
-			defineConfig({
-				migrations: { migrator },
-				plugins,
 				seeds: { seeder },
 			})
 		})
@@ -307,6 +296,18 @@ describe('defineConfig', () => {
 			})
 		})
 
+		it('should not type-error when also passing `destroyOnExit`', () => {
+			defineConfig({
+				destroyOnExit: true,
+				kysely,
+			})
+
+			defineConfig({
+				destroyOnExit: false,
+				kysely,
+			})
+		})
+
 		it('should type-error when also passing a dialect instance', () => {
 			defineConfig({
 				kysely,
@@ -339,8 +340,8 @@ describe('defineConfig', () => {
 			})
 
 			defineConfig({
-				plugins,
 				// @ts-expect-error
+				plugins,
 				kysely,
 			})
 		})
@@ -353,6 +354,18 @@ describe('defineConfig', () => {
 			})
 		})
 
+		it('should not type-error when also passing `destroyOnExit`', () => {
+			defineConfig({
+				destroyOnExit: true,
+				dialect,
+			})
+
+			defineConfig({
+				destroyOnExit: false,
+				dialect,
+			})
+		})
+
 		it('should type-error when also passing a dialect config', () => {
 			defineConfig({
 				dialect,
@@ -361,8 +374,8 @@ describe('defineConfig', () => {
 			})
 
 			defineConfig({
-				// @ts-expect-error
 				dialectConfig,
+				// @ts-expect-error
 				dialect,
 			})
 		})
@@ -399,8 +412,8 @@ describe('defineConfig', () => {
 			})
 
 			defineConfig({
-				// @ts-expect-error
 				dialectConfig,
+				// @ts-expect-error
 				dialect: 'pg',
 			})
 		})
@@ -425,6 +438,22 @@ describe('defineConfig', () => {
 				dialectConfig,
 				// @ts-expect-error
 				kysely,
+			})
+		})
+
+		it('should type-error when also passing `destroyOnExit`', () => {
+			// @ts-expect-error
+			defineConfig({
+				dialect: 'better-sqlite3',
+				dialectConfig,
+				destroyOnExit: true,
+			})
+
+			// @ts-expect-error
+			defineConfig({
+				dialect: 'better-sqlite3',
+				dialectConfig,
+				destroyOnExit: false,
 			})
 		})
 	})
@@ -473,18 +502,22 @@ function init() {
 	const migrationProvider = new TSFileMigrationProvider({
 		migrationFolder: 'migrations',
 	})
-	const migrator = new Migrator({
-		db: kysely,
-		provider: migrationProvider,
-	})
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	const migrator = (db: Kysely<any>) =>
+		new Migrator({
+			db,
+			provider: migrationProvider,
+		})
 
 	const seedProvider = new FileSeedProvider({
 		seedFolder: 'seeds',
 	})
-	const seeder = new Seeder({
-		db: kysely,
-		provider: seedProvider,
-	})
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	const seeder = (db: Kysely<any>) =>
+		new Seeder({
+			db,
+			provider: seedProvider,
+		})
 
 	return {
 		dialect,


### PR DESCRIPTION
Hey 👋 

closes #194 

The current config definition API is flawed. It allows for situations where the wrong `Kysely` instance is destroyed, resulting in the process not exiting.

This PR makes it so that `migrations.migrator` and `seeds.seeder` are callbacks that receive the (resolved) `Kysely` instance. This promotes using that one instance, so that the right instance gets destroyed.

An additional optional `destroyOnExit` property is introduced. By default, it is `true`. When `false`, the (resolved) `Kysely` instance will not be destroyed. This is suitable for programmatic usage of commands (will be exposed in the future), when there's a need to reuse the connections/pools for additional things after the command has been executed.