### PR TITLE
feat: better environment-specific configuration support with factories and stuff.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js 22
+      - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js 22
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js 22
+      - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: "pnpm"
 
       - name: Install dependencies
@@ -36,9 +36,9 @@ jobs:
   node:
     strategy:
       matrix:
-        node-version: [18, 20, 22, 23]
+        node-version: [20, 22, 24]
         os: [macos-latest, ubuntu-latest, windows-latest]
-        type: [cjs, esm, esm-tsconfig-paths, esm-top-level-await]
+        type: [cjs, esm, esm-tsconfig-paths, esm-top-level-await, esm-environments]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -69,6 +69,10 @@ jobs:
           
           if [[ ${{ matrix.os }} == 'windows-latest' ]]; then
             ADDITIONAL_FLAGS+=" --cwd=%cd%"
+          fi
+
+          if [[ ${{ matrix.type}} == 'esm-environments' ]]; then
+            ADDITIONAL_FLAGS+=" -e lib2"
           fi
 
           echo "ADDITIONAL_FLAGS=$ADDITIONAL_FLAGS" >> $GITHUB_OUTPUT
@@ -107,10 +111,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js 22
+      - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: "pnpm"
 
       - uses: oven-sh/setup-bun@v2
@@ -156,10 +160,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js 22
+      - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: "pnpm"
 
       - uses: denoland/setup-deno@v2

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ kysely seed <command>
 > We also provide `kysely seed list`, which is not part of [Knex.js](https://knexjs.org) 
 CLI.
 
+#### Environment-specific configuration
+
+See [c12 docs](https://github.com/unjs/c12#environment-specific-configuration) and the following [example](https://github.com/kysely-org/kysely-ctl/blob/main/examples/node-esm-environments/.config/kysely.config.ts)
+
 ## Acknowledgements
 
 [acro5piano](https://github.com/acro5piano) who built [kysely-migration-cli](https://github.com/acro5piano/kysely-migration-cli) 

--- a/examples/node-esm-environments/.config/kysely.config.ts
+++ b/examples/node-esm-environments/.config/kysely.config.ts
@@ -1,0 +1,25 @@
+import database from 'better-sqlite3'
+import { DUMMY_DIALECT_CONFIG, defineConfig } from 'kysely-ctl'
+
+export default defineConfig({
+	dialect: 'better-sqlite3',
+	dialectConfig: DUMMY_DIALECT_CONFIG,
+	$env: {
+		lib1: {
+			dialectConfig: () => ({
+				database: database('./packages/lib1/example.db'),
+			}),
+			migrations: {
+				migrationFolder: './packages/lib1/migrations',
+			},
+		},
+		lib2: {
+			dialectConfig: () => ({
+				database: database('./packages/lib2/example.db'),
+			}),
+			migrations: {
+				migrationFolder: './packages/lib2/migrations',
+			},
+		},
+	},
+})

--- a/examples/node-esm-environments/package.json
+++ b/examples/node-esm-environments/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "node-esm-environments",
+	"type": "module",
+	"scripts": {
+		"lib1:migrate:latest": "kysely migrate latest -e lib1",
+		"lib2:migrate:latest": "kysely migrate latest -e lib2",
+        "migrate:latest": "run-p -c -l \"*:migrate:latest --no-outdated-check\""
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^7.6.12",
+		"kysely-ctl": "link:../..",
+		"npm-run-all": "^4.1.5"
+	},
+	"dependencies": {
+		"better-sqlite3": "^11.9.1",
+		"kysely": "^0.28.0"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"better-sqlite3"
+		]
+	}
+}

--- a/examples/node-esm-environments/packages/lib1/package.json
+++ b/examples/node-esm-environments/packages/lib1/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "@example/lib1"
+}

--- a/examples/node-esm-environments/packages/lib2/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/node-esm-environments/packages/lib2/migrations/1716743937856_add_table_moshe.ts
@@ -1,0 +1,12 @@
+import { setTimeout } from 'node:timers/promises'
+import type { Kysely } from 'kysely'
+
+await setTimeout(0)
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.dropTable('moshe').execute()
+}

--- a/examples/node-esm-environments/packages/lib2/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/node-esm-environments/packages/lib2/migrations/1716743937856_add_table_moshe.ts
@@ -1,7 +1,4 @@
-import { setTimeout } from 'node:timers/promises'
 import type { Kysely } from 'kysely'
-
-await setTimeout(0)
 
 export async function up(db: Kysely<any>): Promise<void> {
 	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()

--- a/examples/node-esm-environments/packages/lib2/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/node-esm-environments/packages/lib2/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,7 +1,4 @@
-import { setTimeout } from 'node:timers/promises'
 import type { Kysely } from 'kysely'
-
-await setTimeout(0)
 
 export async function up(db: Kysely<any>): Promise<void> {
 	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()

--- a/examples/node-esm-environments/packages/lib2/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/node-esm-environments/packages/lib2/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,0 +1,12 @@
+import { setTimeout } from 'node:timers/promises'
+import type { Kysely } from 'kysely'
+
+await setTimeout(0)
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.alterTable('moshe').dropColumn('is_moshe').execute()
+}

--- a/examples/node-esm-environments/packages/lib2/package.json
+++ b/examples/node-esm-environments/packages/lib2/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "@example/lib2"
+}

--- a/examples/node-esm-environments/pnpm-lock.yaml
+++ b/examples/node-esm-environments/pnpm-lock.yaml
@@ -1,0 +1,1530 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      better-sqlite3:
+        specifier: ^11.9.1
+        version: 11.10.0
+      kysely:
+        specifier: ^0.28.0
+        version: 0.28.2
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      kysely-ctl:
+        specifier: link:../..
+        version: link:../..
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+
+  packages/lib1: {}
+
+  packages/lib2: {}
+
+packages:
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
+  '@types/node@22.15.18':
+    resolution: {integrity: sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==}
+
+  ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+
+  color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@6.0.6:
+    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
+    engines: {node: '>=4.8'}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
+  detect-libc@2.0.4:
+    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  end-of-stream@1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+
+  error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  es-abstract@1.23.9:
+    resolution: {integrity: sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
+    engines: {node: '>= 0.4'}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
+  is-generator-function@1.1.0:
+    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
+    engines: {node: '>= 0.4'}
+
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  json-parse-better-errors@1.0.2:
+    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
+
+  kysely@0.28.2:
+    resolution: {integrity: sha512-4YAVLoF0Sf0UTqlhgQMFU9iQECdah7n+13ANkiuVfRvlK+uI0Etbgd7bVP36dKlG+NXWbhGua8vnGt+sdhvT7A==}
+    engines: {node: '>=18.0.0'}
+
+  load-json-file@4.0.0:
+    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
+    engines: {node: '>=4'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  nice-try@1.0.5:
+    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
+
+  node-abi@3.75.0:
+    resolution: {integrity: sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==}
+    engines: {node: '>=10'}
+
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
+  npm-run-all@4.1.5:
+    resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
+    engines: {node: '>= 4'}
+    hasBin: true
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
+
+  parse-json@4.0.0:
+    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
+    engines: {node: '>=4'}
+
+  path-key@2.0.1:
+    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
+    engines: {node: '>=4'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-type@3.0.0:
+    resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
+    engines: {node: '>=4'}
+
+  pidtree@0.3.1:
+    resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
+  pify@3.0.0:
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
+    engines: {node: '>=4'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  pump@3.0.2:
+    resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  read-pkg@3.0.0:
+    resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
+    engines: {node: '>=4'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  safe-array-concat@1.1.3:
+    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+    engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
+
+  shebang-command@1.2.0:
+    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
+    engines: {node: '>=0.10.0'}
+
+  shebang-regex@1.0.0:
+    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
+    engines: {node: '>=0.10.0'}
+
+  shell-quote@1.8.2:
+    resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.21:
+    resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
+
+  string.prototype.padend@3.1.6:
+    resolution: {integrity: sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tar-fs@2.1.2:
+    resolution: {integrity: sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.19:
+    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
+    engines: {node: '>= 0.4'}
+
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+snapshots:
+
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.15.18
+
+  '@types/node@22.15.18':
+    dependencies:
+      undici-types: 6.21.0
+
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.9
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
+  async-function@1.0.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  balanced-match@1.0.2: {}
+
+  base64-js@1.5.1: {}
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  brace-expansion@1.1.11:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  chalk@2.4.2:
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+
+  chownr@1.1.4: {}
+
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
+
+  color-name@1.1.3: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@6.0.6:
+    dependencies:
+      nice-try: 1.0.5
+      path-key: 2.0.1
+      semver: 5.7.2
+      shebang-command: 1.2.0
+      which: 1.3.1
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
+  detect-libc@2.0.4: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  end-of-stream@1.4.4:
+    dependencies:
+      once: 1.4.0
+
+  error-ex@1.3.2:
+    dependencies:
+      is-arrayish: 0.2.1
+
+  es-abstract@1.23.9:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-regex: 1.2.1
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.3
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.19
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
+
+  escape-string-regexp@1.0.5: {}
+
+  expand-template@2.0.3: {}
+
+  file-uri-to-path@1.0.0: {}
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
+  fs-constants@1.0.0: {}
+
+  function-bind@1.1.2: {}
+
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.2
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+
+  github-from-package@0.0.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-bigints@1.1.0: {}
+
+  has-flag@3.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hosted-git-info@2.8.9: {}
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-generator-function@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-map@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.19
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@2.0.5: {}
+
+  isexe@2.0.0: {}
+
+  json-parse-better-errors@1.0.2: {}
+
+  kysely@0.28.2: {}
+
+  load-json-file@4.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      parse-json: 4.0.0
+      pify: 3.0.0
+      strip-bom: 3.0.0
+
+  math-intrinsics@1.1.0: {}
+
+  memorystream@0.3.1: {}
+
+  mimic-response@3.1.0: {}
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.11
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  napi-build-utils@2.0.0: {}
+
+  nice-try@1.0.5: {}
+
+  node-abi@3.75.0:
+    dependencies:
+      semver: 7.7.2
+
+  normalize-package-data@2.5.0:
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.10
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
+
+  npm-run-all@4.1.5:
+    dependencies:
+      ansi-styles: 3.2.1
+      chalk: 2.4.2
+      cross-spawn: 6.0.6
+      memorystream: 0.3.1
+      minimatch: 3.1.2
+      pidtree: 0.3.1
+      read-pkg: 3.0.0
+      shell-quote: 1.8.2
+      string.prototype.padend: 3.1.6
+
+  object-inspect@1.13.4: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
+
+  parse-json@4.0.0:
+    dependencies:
+      error-ex: 1.3.2
+      json-parse-better-errors: 1.0.2
+
+  path-key@2.0.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-type@3.0.0:
+    dependencies:
+      pify: 3.0.0
+
+  pidtree@0.3.1: {}
+
+  pify@3.0.0: {}
+
+  possible-typed-array-names@1.1.0: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.0.4
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.75.0
+      pump: 3.0.2
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.2
+      tunnel-agent: 0.6.0
+
+  pump@3.0.2:
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  read-pkg@3.0.0:
+    dependencies:
+      load-json-file: 4.0.0
+      normalize-package-data: 2.5.0
+      path-type: 3.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.9
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  safe-array-concat@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-buffer@5.2.1: {}
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
+  semver@5.7.2: {}
+
+  semver@7.7.2: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+
+  shebang-command@1.2.0:
+    dependencies:
+      shebang-regex: 1.0.0
+
+  shebang-regex@1.0.0: {}
+
+  shell-quote@1.8.2: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.21
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.21
+
+  spdx-license-ids@3.0.21: {}
+
+  string.prototype.padend@3.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.9
+      es-object-atoms: 1.1.1
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.23.9
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-bom@3.0.0: {}
+
+  strip-json-comments@2.0.1: {}
+
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  tar-fs@2.1.2:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.2
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.4
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
+
+  undici-types@6.21.0: {}
+
+  util-deprecate@1.0.2: {}
+
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.0
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.19
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.19:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
+  wrappy@1.0.2: {}

--- a/examples/node-esm-environments/pnpm-workspace.yaml
+++ b/examples/node-esm-environments/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/examples/node-esm-environments/tsconfig.json
+++ b/examples/node-esm-environments/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": [".config/**/*", "migrations"]
+}

--- a/src/config/dummy-dialect-config.mts
+++ b/src/config/dummy-dialect-config.mts
@@ -1,0 +1,5 @@
+export function DUMMY_DIALECT_CONFIG(): never {
+	throw new Error(
+		'`DUMMY_DIALECT_CONFIG` is a dummy dialect config that should be overriden by environment-specific configuration. You must run the command with the `-e <environment>` flag and make sure there is a configuration for `<environment>` in your `kysely.config` file.',
+	)
+}

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,4 +1,5 @@
 export * from './config/define-config.mjs'
+export * from './config/dummy-dialect-config.mjs'
 export type {
 	KyselyCoreDialect,
 	KyselyCTLConfig,

--- a/src/kysely/get-dialect.mts
+++ b/src/kysely/get-dialect.mts
@@ -5,42 +5,44 @@ import {
 	SqliteDialect,
 } from 'kysely'
 import type { ResolvedKyselyCTLConfig } from '../config/kysely-ctl-config.mjs'
-import { isObject } from '../utils/is-object.mjs'
+import { hydrate } from '../utils/hydrate.mjs'
 
 export async function getDialect(
 	config: ResolvedKyselyCTLConfig,
 ): Promise<Dialect> {
-	const { dialect, dialectConfig } = config
+	const { dialect } = config
 
 	if (!dialect) {
 		throw new Error('No dialect provided')
 	}
 
-	if (isObject(dialect)) {
-		return dialect
+	if (typeof dialect !== 'string') {
+		return await hydrate(dialect, [])
 	}
 
+	const dialectConfig = await hydrate(config.dialectConfig, [])
+
 	if (dialect === 'pg') {
-		return new PostgresDialect(dialectConfig)
+		return new PostgresDialect(dialectConfig as never)
 	}
 
 	if (dialect === 'mysql2') {
-		return new MysqlDialect(dialectConfig)
+		return new MysqlDialect(dialectConfig as never)
 	}
 
 	if (dialect === 'tedious') {
 		// since it was introduced only in kysely v0.27.0
 		// and we want to support older versions too
-		return new (await import('kysely')).MssqlDialect(dialectConfig)
+		return new (await import('kysely')).MssqlDialect(dialectConfig as never)
 	}
 
 	if (dialect === 'better-sqlite3') {
-		return new SqliteDialect(dialectConfig)
+		return new SqliteDialect(dialectConfig as never)
 	}
 
 	if (dialect === 'postgres') {
 		return new (await import('kysely-postgres-js')).PostgresJSDialect(
-			dialectConfig,
+			dialectConfig as never,
 		)
 	}
 

--- a/src/kysely/get-kysely.mts
+++ b/src/kysely/get-kysely.mts
@@ -1,6 +1,7 @@
 import { consola } from 'consola'
 import { Kysely } from 'kysely'
 import type { ResolvedKyselyCTLConfig } from '../config/kysely-ctl-config.mjs'
+import { hydrate } from '../utils/hydrate.mjs'
 import { getDialect } from './get-dialect.mjs'
 
 // biome-ignore lint/suspicious/noExplicitAny: `any` is required here, for now.
@@ -11,10 +12,13 @@ export async function getKysely<DB = any>(
 	const { kysely } = config
 
 	if (kysely) {
-		return kysely
+		return await hydrate(kysely, [])
 	}
 
-	const dialect = await getDialect(config)
+	const [dialect, plugins] = await Promise.all([
+		getDialect(config),
+		hydrate(config.plugins, []),
+	])
 
 	return new Kysely<DB>({
 		dialect,
@@ -29,6 +33,6 @@ export async function getKysely<DB = any>(
 					)
 				}
 			: [],
-		plugins: config.plugins,
+		plugins,
 	})
 }

--- a/src/utils/hydrate.mts
+++ b/src/utils/hydrate.mts
@@ -1,0 +1,23 @@
+import type { Factory, OrFactory } from '../config/kysely-ctl-config.mjs'
+
+export async function hydrate<
+	// biome-ignore lint/suspicious/noExplicitAny: it's fine.
+	F extends OrFactory<any, any[]> | undefined,
+	// biome-ignore lint/suspicious/noExplicitAny: it's fine.
+	P extends F extends OrFactory<any, infer A> | undefined ? A : never,
+>(
+	factory: F,
+	parameters: P,
+	defaultValue?: () => F extends OrFactory<infer T> ? T : never,
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+): Promise<Awaited<ReturnType<Extract<F, Factory<any>>>>> {
+	if (factory == null) {
+		return (defaultValue?.() ?? factory) as never
+	}
+
+	if (typeof factory !== 'function') {
+		return factory as never
+	}
+
+	return await factory(...parameters)
+}

--- a/tests/define-config.test-d.ts
+++ b/tests/define-config.test-d.ts
@@ -10,7 +10,7 @@ import {
 	PostgresQueryCompiler,
 	type SqliteDialectConfig,
 } from 'kysely'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
 	FileSeedProvider,
 	Seeder,
@@ -45,11 +45,35 @@ describe('defineConfig', () => {
 				migrations: { migrator },
 				seeds: { seeder },
 			})
+
+			defineConfig({
+				kysely: () => kysely,
+				migrations: { migrator },
+				seeds: { seeder },
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				migrations: { migrator },
+				seeds: { seeder },
+			})
 		})
 
 		it('should not type-error when also passing a dialect instance', () => {
 			defineConfig({
 				dialect,
+				migrations: { migrator },
+				seeds: { seeder },
+			})
+
+			defineConfig({
+				dialect: () => dialect,
+				migrations: { migrator },
+				seeds: { seeder },
+			})
+
+			defineConfig({
+				dialect: async () => dialect,
 				migrations: { migrator },
 				seeds: { seeder },
 			})
@@ -59,6 +83,20 @@ describe('defineConfig', () => {
 			defineConfig({
 				dialect: 'better-sqlite3',
 				dialectConfig,
+				migrations: { migrator },
+				seeds: { seeder },
+			})
+
+			defineConfig({
+				dialect: 'better-sqlite3',
+				dialectConfig: () => dialectConfig,
+				migrations: { migrator },
+				seeds: { seeder },
+			})
+
+			defineConfig({
+				dialect: 'better-sqlite3',
+				dialectConfig: async () => dialectConfig,
 				migrations: { migrator },
 				seeds: { seeder },
 			})
@@ -73,6 +111,18 @@ describe('defineConfig', () => {
 					migrations: { migrator },
 					seeds: { provider: seedProvider },
 				})
+
+				// @ts-expect-error
+				defineConfig({
+					migrations: { migrator },
+					seeds: { provider: () => seedProvider },
+				})
+
+				// @ts-expect-error
+				defineConfig({
+					migrations: { migrator },
+					seeds: { provider: async () => seedProvider },
+				})
 			})
 
 			it('should not type-error when also passing a kysely instance', () => {
@@ -80,6 +130,54 @@ describe('defineConfig', () => {
 					kysely,
 					migrations: { migrator },
 					seeds: { provider: seedProvider },
+				})
+
+				defineConfig({
+					kysely: () => kysely,
+					migrations: { migrator },
+					seeds: { provider: seedProvider },
+				})
+
+				defineConfig({
+					kysely: async () => kysely,
+					migrations: { migrator },
+					seeds: { provider: seedProvider },
+				})
+
+				defineConfig({
+					kysely,
+					migrations: { migrator },
+					seeds: { provider: () => seedProvider },
+				})
+
+				defineConfig({
+					kysely: () => kysely,
+					migrations: { migrator },
+					seeds: { provider: () => seedProvider },
+				})
+
+				defineConfig({
+					kysely: async () => kysely,
+					migrations: { migrator },
+					seeds: { provider: () => seedProvider },
+				})
+
+				defineConfig({
+					kysely,
+					migrations: { migrator },
+					seeds: { provider: async () => seedProvider },
+				})
+
+				defineConfig({
+					kysely: () => kysely,
+					migrations: { migrator },
+					seeds: { provider: async () => seedProvider },
+				})
+
+				defineConfig({
+					kysely: async () => kysely,
+					migrations: { migrator },
+					seeds: { provider: async () => seedProvider },
 				})
 			})
 
@@ -89,6 +187,54 @@ describe('defineConfig', () => {
 					migrations: { migrator },
 					seeds: { provider: seedProvider },
 				})
+
+				defineConfig({
+					dialect: () => dialect,
+					migrations: { migrator },
+					seeds: { provider: seedProvider },
+				})
+
+				defineConfig({
+					dialect: async () => dialect,
+					migrations: { migrator },
+					seeds: { provider: seedProvider },
+				})
+
+				defineConfig({
+					dialect,
+					migrations: { migrator },
+					seeds: { provider: () => seedProvider },
+				})
+
+				defineConfig({
+					dialect: () => dialect,
+					migrations: { migrator },
+					seeds: { provider: () => seedProvider },
+				})
+
+				defineConfig({
+					dialect: async () => dialect,
+					migrations: { migrator },
+					seeds: { provider: () => seedProvider },
+				})
+
+				defineConfig({
+					dialect,
+					migrations: { migrator },
+					seeds: { provider: async () => seedProvider },
+				})
+
+				defineConfig({
+					dialect: () => dialect,
+					migrations: { migrator },
+					seeds: { provider: async () => seedProvider },
+				})
+
+				defineConfig({
+					dialect: async () => dialect,
+					migrations: { migrator },
+					seeds: { provider: async () => seedProvider },
+				})
 			})
 
 			it('should not type-error when also passing a dialect name & config', () => {
@@ -97,6 +243,62 @@ describe('defineConfig', () => {
 					dialectConfig,
 					migrations: { migrator },
 					seeds: { provider: seedProvider },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: () => dialectConfig,
+					migrations: { migrator },
+					seeds: { provider: seedProvider },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: async () => dialectConfig,
+					migrations: { migrator },
+					seeds: { provider: seedProvider },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig,
+					migrations: { migrator },
+					seeds: { provider: () => seedProvider },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: () => dialectConfig,
+					migrations: { migrator },
+					seeds: { provider: () => seedProvider },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: async () => dialectConfig,
+					migrations: { migrator },
+					seeds: { provider: () => seedProvider },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig,
+					migrations: { migrator },
+					seeds: { provider: async () => seedProvider },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: () => dialectConfig,
+					migrations: { migrator },
+					seeds: { provider: async () => seedProvider },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: async () => dialectConfig,
+					migrations: { migrator },
+					seeds: { provider: async () => seedProvider },
 				})
 			})
 		})
@@ -116,11 +318,35 @@ describe('defineConfig', () => {
 					migrations: { migrator },
 					seeds: { seedFolder: 'seeds' },
 				})
+
+				defineConfig({
+					kysely: () => kysely,
+					migrations: { migrator },
+					seeds: { seedFolder: 'seeds' },
+				})
+
+				defineConfig({
+					kysely: async () => kysely,
+					migrations: { migrator },
+					seeds: { seedFolder: 'seeds' },
+				})
 			})
 
 			it('should not type-error when also passing a dialect instance', () => {
 				defineConfig({
 					dialect,
+					migrations: { migrator },
+					seeds: { seedFolder: 'seeds' },
+				})
+
+				defineConfig({
+					dialect: () => dialect,
+					migrations: { migrator },
+					seeds: { seedFolder: 'seeds' },
+				})
+
+				defineConfig({
+					dialect: async () => dialect,
 					migrations: { migrator },
 					seeds: { seedFolder: 'seeds' },
 				})
@@ -130,6 +356,20 @@ describe('defineConfig', () => {
 				defineConfig({
 					dialect: 'better-sqlite3',
 					dialectConfig,
+					migrations: { migrator },
+					seeds: { seedFolder: 'seeds' },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: () => dialectConfig,
+					migrations: { migrator },
+					seeds: { seedFolder: 'seeds' },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: async () => dialectConfig,
 					migrations: { migrator },
 					seeds: { seedFolder: 'seeds' },
 				})
@@ -152,6 +392,24 @@ describe('defineConfig', () => {
 					provider: migrationProvider,
 					// @ts-expect-error
 					migrator,
+				},
+			})
+
+			defineConfig({
+				dialect,
+				migrations: {
+					migrator,
+					// @ts-expect-error
+					provider: () => migrationProvider,
+				},
+			})
+
+			defineConfig({
+				dialect,
+				migrations: {
+					migrator,
+					// @ts-expect-error
+					provider: async () => migrationProvider,
 				},
 			})
 		})
@@ -185,12 +443,72 @@ describe('defineConfig', () => {
 					migrations: { provider: migrationProvider },
 					seeds: { seeder },
 				})
+
+				// @ts-expect-error
+				defineConfig({
+					migrations: { provider: () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				// @ts-expect-error
+				defineConfig({
+					migrations: { provider: async () => migrationProvider },
+					seeds: { seeder },
+				})
 			})
 
 			it('should not type-error when also passing a kysely instance', () => {
 				defineConfig({
 					kysely,
 					migrations: { provider: migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					kysely: () => kysely,
+					migrations: { provider: migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					kysely: async () => kysely,
+					migrations: { provider: migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					kysely,
+					migrations: { provider: () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					kysely: () => kysely,
+					migrations: { provider: () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					kysely: async () => kysely,
+					migrations: { provider: () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					kysely,
+					migrations: { provider: async () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					kysely: () => kysely,
+					migrations: { provider: async () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					kysely: async () => kysely,
+					migrations: { provider: async () => migrationProvider },
 					seeds: { seeder },
 				})
 			})
@@ -201,6 +519,54 @@ describe('defineConfig', () => {
 					migrations: { provider: migrationProvider },
 					seeds: { seeder },
 				})
+
+				defineConfig({
+					dialect: () => dialect,
+					migrations: { provider: migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: async () => dialect,
+					migrations: { provider: migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect,
+					migrations: { provider: () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: () => dialect,
+					migrations: { provider: () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: async () => dialect,
+					migrations: { provider: () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect,
+					migrations: { provider: async () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: () => dialect,
+					migrations: { provider: async () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: async () => dialect,
+					migrations: { provider: async () => migrationProvider },
+					seeds: { seeder },
+				})
 			})
 
 			it('should not type-error when also passing a dialect name & config', () => {
@@ -208,6 +574,62 @@ describe('defineConfig', () => {
 					dialect: 'better-sqlite3',
 					dialectConfig,
 					migrations: { provider: migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: () => dialectConfig,
+					migrations: { provider: migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: async () => dialectConfig,
+					migrations: { provider: migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig,
+					migrations: { provider: () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: () => dialectConfig,
+					migrations: { provider: () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: async () => dialectConfig,
+					migrations: { provider: () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig,
+					migrations: { provider: async () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: () => dialectConfig,
+					migrations: { provider: async () => migrationProvider },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: async () => dialectConfig,
+					migrations: { provider: async () => migrationProvider },
 					seeds: { seeder },
 				})
 			})
@@ -228,11 +650,35 @@ describe('defineConfig', () => {
 					migrations: { migrationFolder: 'migrations' },
 					seeds: { seeder },
 				})
+
+				defineConfig({
+					kysely: () => kysely,
+					migrations: { migrationFolder: 'migrations' },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					kysely: async () => kysely,
+					migrations: { migrationFolder: 'migrations' },
+					seeds: { seeder },
+				})
 			})
 
 			it('should not type-error when also passing a dialect instance', () => {
 				defineConfig({
 					dialect,
+					migrations: { migrationFolder: 'migrations' },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: () => dialect,
+					migrations: { migrationFolder: 'migrations' },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: async () => dialect,
 					migrations: { migrationFolder: 'migrations' },
 					seeds: { seeder },
 				})
@@ -242,6 +688,20 @@ describe('defineConfig', () => {
 				defineConfig({
 					dialect: 'better-sqlite3',
 					dialectConfig,
+					migrations: { migrationFolder: 'migrations' },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: () => dialectConfig,
+					migrations: { migrationFolder: 'migrations' },
+					seeds: { seeder },
+				})
+
+				defineConfig({
+					dialect: 'better-sqlite3',
+					dialectConfig: async () => dialectConfig,
 					migrations: { migrationFolder: 'migrations' },
 					seeds: { seeder },
 				})
@@ -266,6 +726,78 @@ describe('defineConfig', () => {
 					seeder,
 				},
 			})
+
+			defineConfig({
+				kysely,
+				seeds: {
+					provider: () => seedProvider,
+					// @ts-expect-error
+					seeder,
+				},
+			})
+
+			defineConfig({
+				kysely,
+				seeds: {
+					provider: async () => seedProvider,
+					// @ts-expect-error
+					seeder,
+				},
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+				seeds: {
+					provider: seedProvider,
+					// @ts-expect-error
+					seeder,
+				},
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+				seeds: {
+					provider: () => seedProvider,
+					// @ts-expect-error
+					seeder,
+				},
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+				seeds: {
+					provider: async () => seedProvider,
+					// @ts-expect-error
+					seeder,
+				},
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				seeds: {
+					provider: seedProvider,
+					// @ts-expect-error
+					seeder,
+				},
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				seeds: {
+					provider: () => seedProvider,
+					// @ts-expect-error
+					seeder,
+				},
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				seeds: {
+					provider: async () => seedProvider,
+					// @ts-expect-error
+					seeder,
+				},
+			})
 		})
 
 		it('should type-error when also passing seed folder', () => {
@@ -286,6 +818,24 @@ describe('defineConfig', () => {
 					seeder,
 				},
 			})
+
+			defineConfig({
+				kysely: () => kysely,
+				seeds: {
+					seeder,
+					// @ts-expect-error
+					seedFolder: 'seeds',
+				},
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				seeds: {
+					seeder,
+					// @ts-expect-error
+					seedFolder: 'seeds',
+				},
+			})
 		})
 	})
 
@@ -293,6 +843,14 @@ describe('defineConfig', () => {
 		it('should not type-error', () => {
 			defineConfig({
 				kysely,
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
 			})
 		})
 
@@ -306,6 +864,26 @@ describe('defineConfig', () => {
 				destroyOnExit: false,
 				kysely,
 			})
+
+			defineConfig({
+				destroyOnExit: true,
+				kysely: () => kysely,
+			})
+
+			defineConfig({
+				destroyOnExit: false,
+				kysely: () => kysely,
+			})
+
+			defineConfig({
+				destroyOnExit: true,
+				kysely: async () => kysely,
+			})
+
+			defineConfig({
+				destroyOnExit: false,
+				kysely: async () => kysely,
+			})
 		})
 
 		it('should type-error when also passing a dialect instance', () => {
@@ -313,6 +891,54 @@ describe('defineConfig', () => {
 				kysely,
 				// @ts-expect-error
 				dialect,
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+				// @ts-expect-error
+				dialect,
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				// @ts-expect-error
+				dialect,
+			})
+
+			defineConfig({
+				kysely,
+				// @ts-expect-error
+				dialect: () => dialect,
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+				// @ts-expect-error
+				dialect: () => dialect,
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				// @ts-expect-error
+				dialect: () => dialect,
+			})
+
+			defineConfig({
+				kysely,
+				// @ts-expect-error
+				dialect: async () => dialect,
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+				// @ts-expect-error
+				dialect: async () => dialect,
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				// @ts-expect-error
+				dialect: async () => dialect,
 			})
 		})
 
@@ -330,6 +956,62 @@ describe('defineConfig', () => {
 				dialectConfig,
 				dialect: 'better-sqlite3',
 			})
+
+			defineConfig({
+				kysely: () => kysely,
+				// @ts-expect-error
+				dialect: 'better-sqlite3',
+				dialectConfig,
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				// @ts-expect-error
+				dialect: 'better-sqlite3',
+				dialectConfig,
+			})
+
+			defineConfig({
+				kysely,
+				// @ts-expect-error
+				dialect: 'better-sqlite3',
+				dialectConfig: () => dialectConfig,
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+				// @ts-expect-error
+				dialect: 'better-sqlite3',
+				dialectConfig: () => dialectConfig,
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				// @ts-expect-error
+				dialect: 'better-sqlite3',
+				dialectConfig: () => dialectConfig,
+			})
+
+			defineConfig({
+				kysely,
+				// @ts-expect-error
+				dialect: 'better-sqlite3',
+				dialectConfig: async () => dialectConfig,
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+				// @ts-expect-error
+				dialect: 'better-sqlite3',
+				dialectConfig: async () => dialectConfig,
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				// @ts-expect-error
+				dialect: 'better-sqlite3',
+				dialectConfig: async () => dialectConfig,
+			})
 		})
 
 		it('should type-error when also passing plugins', () => {
@@ -344,6 +1026,54 @@ describe('defineConfig', () => {
 				plugins,
 				kysely,
 			})
+
+			defineConfig({
+				kysely: () => kysely,
+				// @ts-expect-error
+				plugins,
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				// @ts-expect-error
+				plugins,
+			})
+
+			defineConfig({
+				kysely,
+				// @ts-expect-error
+				plugins: () => plugins,
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+				// @ts-expect-error
+				plugins: () => plugins,
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				// @ts-expect-error
+				plugins: () => plugins,
+			})
+
+			defineConfig({
+				kysely,
+				// @ts-expect-error
+				plugins: async () => plugins,
+			})
+
+			defineConfig({
+				kysely: () => kysely,
+				// @ts-expect-error
+				plugins: async () => plugins,
+			})
+
+			defineConfig({
+				kysely: async () => kysely,
+				// @ts-expect-error
+				plugins: async () => plugins,
+			})
 		})
 	})
 
@@ -351,6 +1081,14 @@ describe('defineConfig', () => {
 		it('should not type-error', () => {
 			defineConfig({
 				dialect,
+			})
+
+			defineConfig({
+				dialect: () => dialect,
+			})
+
+			defineConfig({
+				dialect: async () => dialect,
 			})
 		})
 
@@ -363,6 +1101,26 @@ describe('defineConfig', () => {
 			defineConfig({
 				destroyOnExit: false,
 				dialect,
+			})
+
+			defineConfig({
+				destroyOnExit: true,
+				dialect: () => dialect,
+			})
+
+			defineConfig({
+				destroyOnExit: false,
+				dialect: () => dialect,
+			})
+
+			defineConfig({
+				destroyOnExit: true,
+				dialect: async () => dialect,
+			})
+
+			defineConfig({
+				destroyOnExit: false,
+				dialect: async () => dialect,
 			})
 		})
 
@@ -378,14 +1136,58 @@ describe('defineConfig', () => {
 				// @ts-expect-error
 				dialect,
 			})
-		})
 
-		it('should type-error when also passing a kysely instance', () => {
+			defineConfig({
+				dialect: () => dialect,
+				// @ts-expect-error
+				dialectConfig,
+			})
+
+			defineConfig({
+				dialect: async () => dialect,
+				// @ts-expect-error
+				dialectConfig,
+			})
+
 			defineConfig({
 				dialect,
 				// @ts-expect-error
-				kysely,
+				dialectConfig: () => dialectConfig,
 			})
+
+			defineConfig({
+				dialect: () => dialect,
+				// @ts-expect-error
+				dialectConfig: () => dialectConfig,
+			})
+
+			defineConfig({
+				dialect: async () => dialect,
+				// @ts-expect-error
+				dialectConfig: () => dialectConfig,
+			})
+
+			defineConfig({
+				dialect,
+				// @ts-expect-error
+				dialectConfig: async () => dialectConfig,
+			})
+
+			defineConfig({
+				dialect: () => dialect,
+				// @ts-expect-error
+				dialectConfig: async () => dialectConfig,
+			})
+
+			defineConfig({
+				dialect: async () => dialect,
+				// @ts-expect-error
+				dialectConfig: async () => dialectConfig,
+			})
+		})
+
+		it('should type-error when also passing a kysely instance', () => {
+			expect('already checked above').toBeTruthy()
 		})
 	})
 
@@ -394,6 +1196,16 @@ describe('defineConfig', () => {
 			defineConfig({
 				dialect: 'better-sqlite3',
 				dialectConfig,
+			})
+
+			defineConfig({
+				dialect: 'better-sqlite3',
+				dialectConfig: () => dialectConfig,
+			})
+
+			defineConfig({
+				dialect: 'better-sqlite3',
+				dialectConfig: async () => dialectConfig,
 			})
 		})
 
@@ -416,6 +1228,18 @@ describe('defineConfig', () => {
 				// @ts-expect-error
 				dialect: 'pg',
 			})
+
+			defineConfig({
+				dialect: 'pg',
+				// @ts-expect-error
+				dialectConfig: () => dialectConfig,
+			})
+
+			defineConfig({
+				dialect: 'pg',
+				// @ts-expect-error
+				dialectConfig: async () => dialectConfig,
+			})
 		})
 
 		it('should type-error when name is not expected literal', () => {
@@ -433,12 +1257,7 @@ describe('defineConfig', () => {
 		})
 
 		it('should type-error when also passing a kysely instance', () => {
-			defineConfig({
-				dialect: 'better-sqlite3',
-				dialectConfig,
-				// @ts-expect-error
-				kysely,
-			})
+			expect('already checked above').toBeTruthy()
 		})
 
 		it('should not type-error when also passing `destroyOnExit`', () => {
@@ -451,6 +1270,30 @@ describe('defineConfig', () => {
 			defineConfig({
 				dialect: 'better-sqlite3',
 				dialectConfig,
+				destroyOnExit: false,
+			})
+
+			defineConfig({
+				dialect: 'better-sqlite3',
+				dialectConfig: () => dialectConfig,
+				destroyOnExit: true,
+			})
+
+			defineConfig({
+				dialect: 'better-sqlite3',
+				dialectConfig: () => dialectConfig,
+				destroyOnExit: false,
+			})
+
+			defineConfig({
+				dialect: 'better-sqlite3',
+				dialectConfig: async () => dialectConfig,
+				destroyOnExit: true,
+			})
+
+			defineConfig({
+				dialect: 'better-sqlite3',
+				dialectConfig: async () => dialectConfig,
 				destroyOnExit: false,
 			})
 		})


### PR DESCRIPTION
Hey 👋 

This PR adds factory callback variants to many configurable things, allowing for lazy setup in environment-specific overrides, or when async code is required but top-level await is not support.

It adds `DUMMY_DIALECT_CONFIG` so you can both provide something so TypeScript doesn't yell when using string `dialect` AND to error in a standard way if a command that hydrates `dialectConfig` was run without an `-e` / `--environment` flag (that exists in the configuration).