### PR TITLE
feat: add `--no-transaction` flag for migrate commands.

### DIFF
--- a/src/arguments/common.mts
+++ b/src/arguments/common.mts
@@ -3,7 +3,7 @@ import { CWDArg } from './cwd.mjs'
 import { DebugArg } from './debug.mjs'
 import { EnvironmentArg } from './environment.mjs'
 import { JitiArgs } from './jiti.mjs'
-import { NoOutdatedCheckArg } from './no-outdated-notice.mjs'
+import { NoOutdatedCheckArg } from './no-outdated-check.mjs'
 
 export const CommonArgs = {
 	...CWDArg,

--- a/src/arguments/extension.mts
+++ b/src/arguments/extension.mts
@@ -29,8 +29,7 @@ export function assertExtension(
 	config?: ResolvedKyselyCTLConfig,
 	context?: 'migrations' | 'seeds',
 ): asserts thing is Extension {
-	const allowJS =
-		!config || config[context as keyof ResolvedKyselyCTLConfig]?.allowJS
+	const allowJS = config?.[context || 'migrations'].allowJS ?? true
 
 	if (
 		!allowJS &&

--- a/src/arguments/jiti.mts
+++ b/src/arguments/jiti.mts
@@ -11,7 +11,6 @@ const ExperimentalResolveTSConfigPathsArg = {
 
 const NoFilesystemCachingArg = {
 	'no-filesystem-caching': {
-		default: false,
 		description:
 			'Will not write cache files to disk. See https://github.com/unjs/jiti#fscache for more information.',
 		type: 'boolean',

--- a/src/arguments/migrate.mts
+++ b/src/arguments/migrate.mts
@@ -1,0 +1,13 @@
+import type { ArgsDef } from 'citty'
+
+export const NoTransactionArg = {
+	'no-transaction': {
+		description:
+			"Don't use a transaction when running the migrations. This will not work for now if you've provided your own Migrator factory.",
+		type: 'boolean',
+	},
+} satisfies ArgsDef
+
+export const MigrateArgs = {
+	...NoTransactionArg,
+} satisfies ArgsDef

--- a/src/arguments/no-outdated-check.mts
+++ b/src/arguments/no-outdated-check.mts
@@ -2,7 +2,6 @@ import type { ArgsDef } from 'citty'
 
 export const NoOutdatedCheckArg = {
 	'no-outdated-check': {
-		default: false,
 		description:
 			'Will not check for latest kysely/kysely-ctl versions and notice newer versions exist.',
 		type: 'boolean',

--- a/src/commands/init.mts
+++ b/src/commands/init.mts
@@ -5,7 +5,7 @@ import { join } from 'pathe'
 import { CWDArg } from '../arguments/cwd.mjs'
 import { DebugArg } from '../arguments/debug.mjs'
 import { assertExtension, ExtensionArg } from '../arguments/extension.mjs'
-import { NoOutdatedCheckArg } from '../arguments/no-outdated-notice.mjs'
+import { NoOutdatedCheckArg } from '../arguments/no-outdated-check.mjs'
 import { configFileExists, getConfig } from '../config/get-config.mjs'
 import { getTemplateExtension } from '../utils/get-template-extension.mjs'
 

--- a/src/commands/migrate/down.mts
+++ b/src/commands/migrate/down.mts
@@ -1,6 +1,7 @@
 import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { CommonArgs } from '../../arguments/common.mjs'
+import { MigrateArgs } from '../../arguments/migrate.mjs'
 import { createMigrationNameArg } from '../../arguments/migration-name.mjs'
 import { isWrongDirection } from '../../kysely/is-wrong-direction.mjs'
 import { processMigrationResultSet } from '../../kysely/process-migration-result-set.mjs'
@@ -9,6 +10,7 @@ import { createSubcommand } from '../../utils/create-subcommand.mjs'
 
 const args = {
 	...CommonArgs,
+	...MigrateArgs,
 	...createMigrationNameArg(),
 } satisfies ArgsDef
 

--- a/src/commands/migrate/latest.mts
+++ b/src/commands/migrate/latest.mts
@@ -1,12 +1,14 @@
 import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { CommonArgs } from '../../arguments/common.mjs'
+import { MigrateArgs } from '../../arguments/migrate.mjs'
 import { processMigrationResultSet } from '../../kysely/process-migration-result-set.mjs'
 import { usingMigrator } from '../../kysely/using-migrator.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
 
 const args = {
 	...CommonArgs,
+	...MigrateArgs,
 } satisfies ArgsDef
 
 const BaseLatestCommand = {

--- a/src/commands/migrate/rollback.mts
+++ b/src/commands/migrate/rollback.mts
@@ -2,6 +2,7 @@ import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { NO_MIGRATIONS } from 'kysely'
 import { CommonArgs } from '../../arguments/common.mjs'
+import { MigrateArgs } from '../../arguments/migrate.mjs'
 import { processMigrationResultSet } from '../../kysely/process-migration-result-set.mjs'
 import { usingMigrator } from '../../kysely/using-migrator.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
@@ -13,6 +14,7 @@ const args = {
 		type: 'boolean',
 	},
 	...CommonArgs,
+	...MigrateArgs,
 } satisfies ArgsDef
 
 const BaseRollbackCommand = {

--- a/src/commands/migrate/up.mts
+++ b/src/commands/migrate/up.mts
@@ -1,6 +1,7 @@
 import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { CommonArgs } from '../../arguments/common.mjs'
+import { MigrateArgs } from '../../arguments/migrate.mjs'
 import { createMigrationNameArg } from '../../arguments/migration-name.mjs'
 import { isWrongDirection } from '../../kysely/is-wrong-direction.mjs'
 import { processMigrationResultSet } from '../../kysely/process-migration-result-set.mjs'
@@ -9,6 +10,7 @@ import { createSubcommand } from '../../utils/create-subcommand.mjs'
 
 const args = {
 	...CommonArgs,
+	...MigrateArgs,
 	...createMigrationNameArg(),
 } satisfies ArgsDef
 

--- a/src/config/get-config.mts
+++ b/src/config/get-config.mts
@@ -5,6 +5,7 @@ import { getCWD } from './get-cwd.mjs'
 import { getMillisPrefix } from './get-file-prefix.mjs'
 import type {
 	KyselyCTLConfig,
+	MigrationsBaseConfig,
 	ResolvedKyselyCTLConfig,
 } from './kysely-ctl-config.mjs'
 
@@ -14,7 +15,7 @@ export interface GetConfigArgs {
 	environment?: string
 	'experimental-resolve-tsconfig-paths'?: boolean
 	'filesystem-caching'?: boolean
-	transaction?: false
+	transaction?: boolean
 }
 
 export async function getConfig(
@@ -53,13 +54,17 @@ export async function getConfig(
 			allowJS: false,
 			getMigrationPrefix: getMillisPrefix,
 			migrationFolder: 'migrations',
-			...(config.migrations || {}),
+			...config.migrations,
+			disableTransactions:
+				args.transaction === false ||
+				(config.migrations as MigrationsBaseConfig | undefined)
+					?.disableTransactions,
 		},
 		seeds: {
 			allowJS: false,
 			getSeedPrefix: getMillisPrefix,
 			seedFolder: 'seeds',
-			...(config.seeds || {}),
+			...config.seeds,
 		},
 	}
 }

--- a/src/config/get-config.mts
+++ b/src/config/get-config.mts
@@ -14,7 +14,7 @@ export interface GetConfigArgs {
 	environment?: string
 	'experimental-resolve-tsconfig-paths'?: boolean
 	'filesystem-caching'?: boolean
-	'no-transaction'?: boolean
+	transaction?: false
 }
 
 export async function getConfig(

--- a/src/config/get-config.mts
+++ b/src/config/get-config.mts
@@ -14,6 +14,7 @@ export interface GetConfigArgs {
 	environment?: string
 	'experimental-resolve-tsconfig-paths'?: boolean
 	'filesystem-caching'?: boolean
+	'no-transaction'?: boolean
 }
 
 export async function getConfig(

--- a/src/kysely/get-migrator.mts
+++ b/src/kysely/get-migrator.mts
@@ -28,5 +28,11 @@ export async function getMigrator(
 			}),
 	)
 
-	return new Migrator({ ...migratorOptions, db: kysely, provider })
+	return new Migrator({
+		...migratorOptions,
+		db: kysely,
+		disableTransactions:
+			args['no-transaction'] ?? migratorOptions.disableTransactions,
+		provider,
+	})
 }

--- a/src/kysely/get-migrator.mts
+++ b/src/kysely/get-migrator.mts
@@ -28,11 +28,5 @@ export async function getMigrator(
 			}),
 	)
 
-	return new Migrator({
-		...migratorOptions,
-		db: kysely,
-		disableTransactions:
-			args.transaction === false || migratorOptions.disableTransactions,
-		provider,
-	})
+	return new Migrator({ ...migratorOptions, db: kysely, provider })
 }

--- a/src/kysely/get-migrator.mts
+++ b/src/kysely/get-migrator.mts
@@ -32,7 +32,7 @@ export async function getMigrator(
 		...migratorOptions,
 		db: kysely,
 		disableTransactions:
-			args['no-transaction'] ?? migratorOptions.disableTransactions,
+			args.transaction === false || migratorOptions.disableTransactions,
 		provider,
 	})
 }


### PR DESCRIPTION
Hey :wave:

This PR adds the `--no-transaction` flag to allow using `disableTransactions` options in `Migrator` props.

This will not work if a user configured a custom Migrator factory. We need https://github.com/kysely-org/kysely/pull/1517 for it to work in all situations.