### PR TITLE
fix: mishandling of `tsconfig`s that don't extend anything when `--experimental-resolve-tsconfig-paths`.

### DIFF
--- a/examples/node-esm-tsconfig-paths-no-baseurl/tsconfig.json
+++ b/examples/node-esm-tsconfig-paths-no-baseurl/tsconfig.json
@@ -4,6 +4,5 @@
 		 	"@/*": ["./src/*"]
 		}
 	},
-	"extends": "../../tsconfig.base.json",
 	"include": [".config/**/*", "src", "migrations"]
 }

--- a/src/utils/jiti.mts
+++ b/src/utils/jiti.mts
@@ -50,7 +50,7 @@ async function getJitiAliasFromTSConfig(): Promise<Record<string, string>> {
 			return {}
 		}
 
-		const { baseUrl = '.' } = (merged.compilerOptions || {}) as CompilerOptions
+		const { baseUrl = '.' } = (merged?.compilerOptions || {}) as CompilerOptions
 		// biome-ignore lint/style/noNonNullAssertion: paths != null => filepath != null
 		const dirpath = dirname(filepath!)
 

--- a/src/utils/tsconfig.mts
+++ b/src/utils/tsconfig.mts
@@ -20,11 +20,12 @@ const cache = new TSConfckCache<
 
 export async function getTSConfigs(): Promise<{
 	configs: TSConfigWithPath[]
-	merged: TSConfig
+	merged: TSConfig | undefined | null
 }> {
-	const { extended, tsconfig } = await parse(join(getCWD(), 'index.ts'), {
-		cache,
-	})
+	const { extended, tsconfig, tsconfigFile } = await parse(
+		join(getCWD(), 'index.ts'),
+		{ cache },
+	)
 
 	consola.debug('extended', JSON.stringify(extended, null, 2))
 	consola.debug('tsconfig', JSON.stringify(tsconfig, null, 2))
@@ -34,7 +35,7 @@ export async function getTSConfigs(): Promise<{
 			extended?.map((result) => ({
 				filepath: result.tsconfigFile,
 				tsconfig: result.tsconfig,
-			})) || [],
+			})) || (tsconfig ? [{ filepath: tsconfigFile, tsconfig }] : []),
 		merged: tsconfig,
 	}
 }


### PR DESCRIPTION
Hey 👋 

closes #242.

This PR fixes mishandling of `tsconfig` files that don't have the `extends` prop when `--experimental-resolve-tsconfig-paths` is provided.