### PR TITLE
feat(config): find nearest config.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,10 +80,6 @@ jobs:
             ADDITIONAL_FLAGS+=" --experimental-resolve-tsconfig-paths"
           fi
 
-          if [[ ${{ matrix.os }} == 'windows-latest' ]]; then
-            ADDITIONAL_FLAGS+=" --cwd=%cd%"
-          fi
-
           if [[ ${{ matrix.type}} == 'esm-environments' ]]; then
             ADDITIONAL_FLAGS+=" -e lib2"
           fi
@@ -118,6 +114,10 @@ jobs:
       - name: kysely migrate:rollback --all ${{ steps.flags.outputs.ADDITIONAL_FLAGS }}
         working-directory: examples/node-${{ matrix.type }}
         run: pnpm kysely migrate:rollback --all ${{ steps.flags.outputs.ADDITIONAL_FLAGS }}
+
+      - name: kysely migrate:list ${{ steps.flags.outputs.ADDITIONAL_FLAGS }} (nearest config search)
+        working-directory: examples/node-${{ matrix.type }}/${{ startsWith(matrix.type, 'esm-environments') && 'packages' || 'migrations' }}
+        run: pnpm kysely migrate:list ${{ steps.flags.outputs.ADDITIONAL_FLAGS }}
 
   bun:
     runs-on: ubuntu-latest
@@ -168,6 +168,10 @@ jobs:
         working-directory: examples/bun
         run: bun --bun kysely migrate:rollback --all --debug
 
+      - name: kysely migrate:list (nearest config search)
+        working-directory: examples/bun/migrations
+        run: bun --bun kysely migrate:list --debug
+
   deno:
     strategy:
       matrix:
@@ -204,7 +208,8 @@ jobs:
 
       - name: Install example dependencies
         if: matrix.config-flavor != 'no-config'
-        run: cd examples/deno-${{ matrix.config-flavor }} && deno install --node-modules-dir && cd ../.. && pnpx tsx ./scripts/localize-deno-dependency.mts
+        working-directory: examples/deno-${{ matrix.config-flavor }}
+        run: deno install --node-modules-dir
 
       - name: kysely -v
         working-directory: examples/deno-${{ matrix.config-flavor }}
@@ -225,3 +230,7 @@ jobs:
       - name: kysely migrate:rollback --all
         working-directory: examples/deno-${{ matrix.config-flavor }}
         run: deno task kysely migrate:rollback --all --debug
+
+      - name: kysely migrate:list (nearest config search)
+        working-directory: examples/deno-${{ matrix.config-flavor }}/migrations
+        run: deno task kysely migrate:list --debug

--- a/examples/deno-deno-json/deno.json
+++ b/examples/deno-deno-json/deno.json
@@ -1,6 +1,7 @@
 {
 	"tasks": {
-		"kysely": "deno run -A ../../dist/bin.js"
+		"kysely": "deno run -A ../../dist/bin.js",
+		"prekysely": "pnpx tsx ../../scripts/localize-deno-dependency.mts"
 	},
 	"imports": {
 		"@jsr/db__sqlite": "npm:@jsr/db__sqlite@^0.12.0",

--- a/examples/deno-package-json/package.json
+++ b/examples/deno-package-json/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "deno-package-json",
 	"scripts": {
-		"kysely": "kysely"
+		"kysely": "kysely",
+		"prekysely": "pnpx tsx ../../scripts/localize-deno-dependency.mts"
 	},
 	"devDependencies": {
 		"kysely-ctl": "^0.12.2"

--- a/src/config/get-config.mts
+++ b/src/config/get-config.mts
@@ -1,5 +1,7 @@
 import { loadConfig } from 'c12'
 import { consola } from 'consola'
+import { dirname } from 'pathe'
+import { findNearestFile } from 'pkg-types'
 import { getJiti } from '../utils/jiti.mjs'
 import { getCWD } from './get-cwd.mjs'
 import { getMillisPrefix } from './get-file-prefix.mjs'
@@ -20,7 +22,7 @@ export interface GetConfigArgs {
 
 export async function getConfig(
 	args: GetConfigArgs,
-): Promise<ResolvedKyselyCTLConfig> {
+): Promise<ResolvedKyselyCTLConfig | null> {
 	const cwd = getCWD(args)
 
 	const jiti = await getJiti({
@@ -30,8 +32,14 @@ export async function getConfig(
 			args['experimental-resolve-tsconfig-paths'],
 	})
 
+	const configPath = await findNearestKyselyConfigPath()
+
+	if (!configPath) {
+		return null
+	}
+
 	const loadedConfig = await loadConfig<KyselyCTLConfig>({
-		cwd,
+		cwd: configPath,
 		dotenv: true,
 		envName: args.environment,
 		jiti,
@@ -41,7 +49,7 @@ export async function getConfig(
 		rcFile: false,
 	})
 
-	consola.debug(loadedConfig)
+	consola.debug('loadedConfig', loadedConfig)
 
 	const { config, ...configMetadata } = loadedConfig
 
@@ -69,20 +77,50 @@ export async function getConfig(
 	} as never
 }
 
-export function configFileExists(config: ResolvedKyselyCTLConfig): boolean {
-	const { configFile } = config.configMetadata
-
-	return configFile !== undefined && configFile !== 'kysely.config'
-}
-
 export async function getConfigOrFail(
 	args: GetConfigArgs,
 ): Promise<ResolvedKyselyCTLConfig> {
 	const config = await getConfig(args)
 
 	if (!configFileExists(config)) {
-		throw new Error('No config file found')
+		throw new Error(
+			'No config file found. Try creating one by running `kysely init`.',
+		)
 	}
 
 	return config
+}
+
+export function configFileExists(
+	config: ResolvedKyselyCTLConfig | null,
+): config is ResolvedKyselyCTLConfig {
+	if (!config) {
+		return false
+	}
+
+	const { configFile } = config.configMetadata
+
+	return configFile !== undefined && configFile !== 'kysely.config'
+}
+
+async function findNearestKyselyConfigPath(): Promise<string | null> {
+	try {
+		const kyselyConfigPath = await findNearestFile(
+			[
+				'.config/kysely.config.ts',
+				'kysely.config.ts',
+				'.config/kysely.config.mts',
+				'kysely.config.mts',
+				'.config/kysely.config.cts',
+				'kysely.config.cts',
+			],
+			{ startingFrom: getCWD() },
+		)
+
+		consola.debug('found kysely config file at', kyselyConfigPath)
+
+		return dirname(kyselyConfigPath)
+	} catch {
+		return null
+	}
 }


### PR DESCRIPTION
Hey 👋 

This PR enhances config loading by allowing `cwd` to be deeper than the location of the config file or `.config` folder. The DX you're used to from `pnpm` and such that allows you to run commands wherever and it always finds your configuration and manifest to make it happen.