### PR TITLE
feat(config): add `-c`/`--config` flag to point to a specific config path, config extension.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
         os: [macos-latest, ubuntu-latest, windows-latest]
-        type: [cjs, esm, esm-tsconfig-paths, esm-tsconfig-paths-inherited, esm-tsconfig-paths-no-baseurl, esm-top-level-await, esm-environments, esm-jsx]
+        type: [cjs, esm, esm-multi-config, esm-tsconfig-paths, esm-tsconfig-paths-inherited, esm-tsconfig-paths-no-baseurl, esm-top-level-await, esm-environments, esm-jsx]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -75,6 +75,10 @@ jobs:
         shell: bash
         run: |
           ADDITIONAL_FLAGS="--debug"
+
+          if [[ ${{ matrix.type }} == 'esm-multi-config' ]]; then
+            ADDITIONAL_FLAGS+=" -c ./.config/kysely.test.config.ts"
+          fi
 
           if [[ ${{ matrix.type }} == 'esm-tsconfig-paths'* ]]; then
             ADDITIONAL_FLAGS+=" --experimental-resolve-tsconfig-paths"
@@ -116,6 +120,7 @@ jobs:
         run: pnpm kysely migrate:rollback --all ${{ steps.flags.outputs.ADDITIONAL_FLAGS }}
 
       - name: kysely migrate:list ${{ steps.flags.outputs.ADDITIONAL_FLAGS }} (nearest config search)
+        if: ${{ matrix.type != 'esm-multi-config' }}
         working-directory: examples/node-${{ matrix.type }}/${{ startsWith(matrix.type, 'esm-environments') && 'packages' || 'migrations' }}
         run: pnpm kysely migrate:list ${{ steps.flags.outputs.ADDITIONAL_FLAGS }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -134,7 +134,7 @@ migrations
 seeds
 !src/seeds
 !examples/**/seeds
-examples/**/example.db
+examples/**/*.db
 
 tsconfig.vitest-temp.json
 .attest

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ export default defineConfig({
 });
 ```
 
-Alternatively, you can pass a `Kysely` instance, instead of `dialect`, `dialectConfig`
-& `plugins`:
+#### Reuse Kysely instance defined elsewhere
+
+You can pass a `Kysely` instance, instead of `dialect`, `dialectConfig` & `plugins`:
 
 ```ts
 import { defineConfig } from "kysely-ctl";
@@ -148,6 +149,8 @@ export default defineConfig({
   // ...
 });
 ```
+
+#### Custom migration/seed file prefixes
 
 To use Knex's timestamp prefixes:
 
@@ -165,9 +168,13 @@ export default defineConfig({
 });
 ```
 
+#### Extending configuration
+
+See [c12 docs](https://github.com/unjs/c12#extending-configuration) and the following [example](https://github.com/kysely-org/kysely-ctl/blob/main/examples/node-esm-multi-config/.config/kysely.test.config.ts).
+
 #### Environment-specific configuration
 
-See [c12 docs](https://github.com/unjs/c12#environment-specific-configuration) and the following [example](https://github.com/kysely-org/kysely-ctl/blob/main/examples/node-esm-environments/.config/kysely.config.ts)
+See [c12 docs](https://github.com/unjs/c12#environment-specific-configuration) and the following [example](https://github.com/kysely-org/kysely-ctl/blob/main/examples/node-esm-environments/.config/kysely.config.ts).
 
 </details>
 

--- a/examples/node-esm-multi-config/.config/kysely.config.ts
+++ b/examples/node-esm-multi-config/.config/kysely.config.ts
@@ -1,0 +1,18 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import database from 'better-sqlite3'
+import { defineConfig } from 'kysely-ctl'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+	dialect: 'better-sqlite3',
+	dialectConfig: () => {
+		// biome-ignore lint/suspicious/noConsole: it's fine
+		console.log('main config loaded!')
+
+		return {
+			database: database(resolve(__dirname, '../example.db')),
+		}
+	},
+})

--- a/examples/node-esm-multi-config/.config/kysely.test.config.ts
+++ b/examples/node-esm-multi-config/.config/kysely.test.config.ts
@@ -1,0 +1,18 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import database from 'better-sqlite3'
+import { defineConfig } from 'kysely-ctl'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+	extends: './kysely.config.ts',
+	dialectConfig: () => {
+		// biome-ignore lint/suspicious/noConsole: it's fine.
+		console.log('test config loaded!')
+
+		return {
+			database: database(resolve(__dirname, '../test.db')),
+		}
+	},
+})

--- a/examples/node-esm-multi-config/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/node-esm-multi-config/migrations/1716743937856_add_table_moshe.ts
@@ -1,0 +1,9 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.dropTable('moshe').execute()
+}

--- a/examples/node-esm-multi-config/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/node-esm-multi-config/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,0 +1,9 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.alterTable('moshe').dropColumn('is_moshe').execute()
+}

--- a/examples/node-esm-multi-config/package.json
+++ b/examples/node-esm-multi-config/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "node-esm-multi-config",
+	"type": "module",
+	"devDependencies": {
+		"@types/better-sqlite3": "7.6.13",
+		"kysely-ctl": "link:../.."
+	},
+	"dependencies": {
+		"better-sqlite3": "12.2.0",
+		"kysely": "0.28.4"
+	}
+}

--- a/examples/node-esm-multi-config/tsconfig.json
+++ b/examples/node-esm-multi-config/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": [".config/**/*", "migrations"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,22 @@ importers:
         specifier: link:../..
         version: link:../..
 
+  examples/node-esm-multi-config:
+    dependencies:
+      better-sqlite3:
+        specifier: 12.2.0
+        version: 12.2.0
+      kysely:
+        specifier: 0.28.5
+        version: 0.28.5
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: 7.6.13
+        version: 7.6.13
+      kysely-ctl:
+        specifier: link:../..
+        version: link:../..
+
   examples/node-esm-top-level-await:
     dependencies:
       better-sqlite3:

--- a/src/arguments/common.mts
+++ b/src/arguments/common.mts
@@ -1,14 +1,14 @@
-import type { ArgsDef } from 'citty'
+import { defineArgs } from '../utils/define-args.mjs'
 import { CWDArg } from './cwd.mjs'
 import { DebugArg } from './debug.mjs'
 import { EnvironmentArg } from './environment.mjs'
 import { JitiArgs } from './jiti.mjs'
 import { NoOutdatedCheckArg } from './no-outdated-check.mjs'
 
-export const CommonArgs = {
+export const CommonArgs = defineArgs({
 	...CWDArg,
 	...DebugArg,
 	...EnvironmentArg,
 	...JitiArgs,
 	...NoOutdatedCheckArg,
-} satisfies ArgsDef
+})

--- a/src/arguments/common.mts
+++ b/src/arguments/common.mts
@@ -1,4 +1,5 @@
 import { defineArgs } from '../utils/define-args.mjs'
+import { ConfigArg } from './config.mjs'
 import { CWDArg } from './cwd.mjs'
 import { DebugArg } from './debug.mjs'
 import { EnvironmentArg } from './environment.mjs'
@@ -6,6 +7,7 @@ import { JitiArgs } from './jiti.mjs'
 import { NoOutdatedCheckArg } from './no-outdated-check.mjs'
 
 export const CommonArgs = defineArgs({
+	...ConfigArg,
 	...CWDArg,
 	...DebugArg,
 	...EnvironmentArg,

--- a/src/arguments/config.mts
+++ b/src/arguments/config.mts
@@ -1,0 +1,12 @@
+import { defineArgs } from '../utils/define-args.mjs'
+
+export const ConfigArg = defineArgs(
+	{
+		config: {
+			alias: 'c',
+			description: 'Path to the config file.',
+			type: 'string',
+		},
+	},
+	true,
+)

--- a/src/arguments/cwd.mts
+++ b/src/arguments/cwd.mts
@@ -1,8 +1,11 @@
-import type { ArgsDef } from 'citty'
+import { defineArgs } from '../utils/define-args.mjs'
 
-export const CWDArg = {
-	cwd: {
-		description: 'The current working directory to use for relative paths.',
-		type: 'string',
+export const CWDArg = defineArgs(
+	{
+		cwd: {
+			description: 'The current working directory to use for relative paths.',
+			type: 'string',
+		},
 	},
-} satisfies ArgsDef
+	true,
+)

--- a/src/arguments/debug.mts
+++ b/src/arguments/debug.mts
@@ -1,9 +1,12 @@
-import type { ArgsDef } from 'citty'
+import { defineArgs } from '../utils/define-args.mjs'
 
-export const DebugArg = {
-	debug: {
-		default: false,
-		description: 'Show debug information.',
-		type: 'boolean',
+export const DebugArg = defineArgs(
+	{
+		debug: {
+			default: false,
+			description: 'Show debug information.',
+			type: 'boolean',
+		},
 	},
-} satisfies ArgsDef
+	true,
+)

--- a/src/arguments/environment.mts
+++ b/src/arguments/environment.mts
@@ -1,11 +1,14 @@
-import type { ArgsDef } from 'citty'
+import { defineArgs } from '../utils/define-args.mjs'
 
-export const EnvironmentArg = {
-	environment: {
-		alias: 'e',
-		description:
-			'Apply environment-specific overrides to the configuration. See https://github.com/unjs/c12#environment-specific-configuration for more information.',
-		type: 'string',
-		valueHint: 'production | development | test | ...',
+export const EnvironmentArg = defineArgs(
+	{
+		environment: {
+			alias: 'e',
+			description:
+				'Apply environment-specific overrides to the configuration. See https://github.com/unjs/c12#environment-specific-configuration for more information.',
+			type: 'string',
+			valueHint: 'production | development | test | ...',
+		},
 	},
-} satisfies ArgsDef
+	true,
+)

--- a/src/arguments/extension.mts
+++ b/src/arguments/extension.mts
@@ -3,7 +3,7 @@ import { defineArgs } from '../utils/define-args.mjs'
 
 const TS_EXTENSIONS = ['ts', 'mts', 'cts'] as const
 const JS_EXTENSIONS = ['js', 'mjs', 'cjs'] as const
-const ALL_EXTENSIONS = [...TS_EXTENSIONS, ...JS_EXTENSIONS] as const
+export const ALL_EXTENSIONS = [...TS_EXTENSIONS, ...JS_EXTENSIONS] as const
 
 export const ExtensionArg = defineArgs(
 	{

--- a/src/arguments/extension.mts
+++ b/src/arguments/extension.mts
@@ -1,19 +1,24 @@
-import type { ArgsDef } from 'citty'
 import type { ResolvedKyselyCTLConfig } from '../config/kysely-ctl-config.mjs'
+import { defineArgs } from '../utils/define-args.mjs'
 
 const TS_EXTENSIONS = ['ts', 'mts', 'cts'] as const
 const JS_EXTENSIONS = ['js', 'mjs', 'cjs'] as const
 const ALL_EXTENSIONS = [...TS_EXTENSIONS, ...JS_EXTENSIONS] as const
 
-export const ExtensionArg = {
-	extension: {
-		alias: 'x',
-		default: 'ts',
-		description: 'The file extension to use.',
-		type: 'string',
-		valueHint: ALL_EXTENSIONS.map((extension) => `"${extension}"`).join(' | '),
+export const ExtensionArg = defineArgs(
+	{
+		extension: {
+			alias: 'x',
+			default: 'ts',
+			description: 'The file extension to use.',
+			type: 'string',
+			valueHint: ALL_EXTENSIONS.map((extension) => `"${extension}"`).join(
+				' | ',
+			),
+		},
 	},
-} satisfies ArgsDef
+	true,
+)
 
 export type Extension = (typeof ALL_EXTENSIONS)[number]
 

--- a/src/arguments/jiti.mts
+++ b/src/arguments/jiti.mts
@@ -1,23 +1,18 @@
-import type { ArgsDef } from 'citty'
+import { defineArgs } from '../utils/define-args.mjs'
 
-const ExperimentalResolveTSConfigPathsArg = {
-	'experimental-resolve-tsconfig-paths': {
-		default: false,
-		description:
-			'Attempts to resolve path aliases using the tsconfig.json file.',
-		type: 'boolean',
+export const JitiArgs = defineArgs(
+	{
+		'experimental-resolve-tsconfig-paths': {
+			default: false,
+			description:
+				'Attempts to resolve path aliases using your `tsconfig.json` file/s.',
+			type: 'boolean',
+		},
+		'no-filesystem-caching': {
+			description:
+				'Will not write cache files to disk. See https://github.com/unjs/jiti#fscache for more information.',
+			type: 'boolean',
+		},
 	},
-} satisfies ArgsDef
-
-const NoFilesystemCachingArg = {
-	'no-filesystem-caching': {
-		description:
-			'Will not write cache files to disk. See https://github.com/unjs/jiti#fscache for more information.',
-		type: 'boolean',
-	},
-} satisfies ArgsDef
-
-export const JitiArgs = {
-	...ExperimentalResolveTSConfigPathsArg,
-	...NoFilesystemCachingArg,
-} satisfies ArgsDef
+	true,
+)

--- a/src/arguments/migrate.mts
+++ b/src/arguments/migrate.mts
@@ -1,13 +1,12 @@
-import type { ArgsDef } from 'citty'
+import { defineArgs } from '../utils/define-args.mjs'
 
-export const NoTransactionArg = {
-	'no-transaction': {
-		description:
-			"Don't use a transaction when running the migrations. This will not work for now if you've provided your own Migrator factory.",
-		type: 'boolean',
+export const MigrateArgs = defineArgs(
+	{
+		'no-transaction': {
+			description:
+				"Don't use a transaction when running the migrations. This will not work for now if you've provided your own Migrator factory.",
+			type: 'boolean',
+		},
 	},
-} satisfies ArgsDef
-
-export const MigrateArgs = {
-	...NoTransactionArg,
-} satisfies ArgsDef
+	true,
+)

--- a/src/arguments/migration-name.mts
+++ b/src/arguments/migration-name.mts
@@ -1,10 +1,13 @@
-import type { ArgsDef } from 'citty'
+import { defineArgs } from '../utils/define-args.mjs'
 
 export const createMigrationNameArg = (required = false) =>
-	({
-		migration_name: {
-			description: 'Migration name to run/undo.',
-			required,
-			type: 'positional',
+	defineArgs(
+		{
+			migration_name: {
+				description: 'Migration name to run/undo.',
+				required,
+				type: 'positional',
+			},
 		},
-	}) satisfies ArgsDef
+		true,
+	)

--- a/src/arguments/no-outdated-check.mts
+++ b/src/arguments/no-outdated-check.mts
@@ -1,9 +1,12 @@
-import type { ArgsDef } from 'citty'
+import { defineArgs } from '../utils/define-args.mjs'
 
-export const NoOutdatedCheckArg = {
-	'no-outdated-check': {
-		description:
-			'Will not check for latest kysely/kysely-ctl versions and notice newer versions exist.',
-		type: 'boolean',
+export const NoOutdatedCheckArg = defineArgs(
+	{
+		'no-outdated-check': {
+			description:
+				'Will not check for latest kysely/kysely-ctl versions and notice newer versions exist.',
+			type: 'boolean',
+		},
 	},
-} satisfies ArgsDef
+	true,
+)

--- a/src/commands/init.mts
+++ b/src/commands/init.mts
@@ -1,5 +1,4 @@
 import { copyFile, mkdir } from 'node:fs/promises'
-import type { ArgsDef, CommandDef, SubCommandsDef } from 'citty'
 import { consola } from 'consola'
 import { join } from 'pathe'
 import { CWDArg } from '../arguments/cwd.mjs'
@@ -8,66 +7,67 @@ import { assertExtension, ExtensionArg } from '../arguments/extension.mjs'
 import { NoOutdatedCheckArg } from '../arguments/no-outdated-check.mjs'
 import { configFileExists, getConfig } from '../config/get-config.mjs'
 import { getCWD } from '../config/get-cwd.mjs'
+import { createSubcommand } from '../utils/create-subcommand.mjs'
+import { defineArgs } from '../utils/define-args.mjs'
+import { defineCommand } from '../utils/define-command.mjs'
 import { getTemplateExtension } from '../utils/get-template-extension.mjs'
 
-const args = {
+const args = defineArgs({
 	...CWDArg,
 	...DebugArg,
 	...ExtensionArg,
 	...NoOutdatedCheckArg,
-} satisfies ArgsDef
+})
 
-export const InitCommand = {
-	init: {
-		meta: {
-			name: 'init',
-			description: 'Create a sample `kysely.config` file',
-		},
-		args,
-		async run(context) {
-			const { args } = context
-			const { extension } = args
+const Command = defineCommand(args, {
+	meta: {
+		description: 'Create a sample `kysely.config` file',
+	},
+	async run(context) {
+		const { args } = context
+		const { extension } = args
 
-			consola.debug(context, [])
+		consola.debug(context, [])
 
-			const config = await getConfig(args)
+		const config = await getConfig(args)
 
-			if (configFileExists(config)) {
-				return consola.warn(
-					`Init skipped: config file already exists at ${config.configMetadata.configFile}`,
-				)
-			}
-
-			assertExtension(extension)
-
-			const configFolderPath = join(getCWD(), '.config')
-
-			consola.debug('Config folder path:', configFolderPath)
-
-			const wasConfigFolderCreated = Boolean(
-				await mkdir(configFolderPath, { recursive: true }),
+		if (configFileExists(config)) {
+			return consola.warn(
+				`Init skipped: config file already exists at ${config.configMetadata.configFile}`,
 			)
+		}
 
-			if (wasConfigFolderCreated) {
-				consola.debug('Config folder created')
-			}
+		assertExtension(extension)
 
-			const filePath = join(configFolderPath, `kysely.config.${extension}`)
+		const configFolderPath = join(getCWD(), '.config')
 
-			consola.debug('File path:', filePath)
+		consola.debug('Config folder path:', configFolderPath)
 
-			const templateExtension = await getTemplateExtension(extension)
+		const wasConfigFolderCreated = Boolean(
+			await mkdir(configFolderPath, { recursive: true }),
+		)
 
-			const templatePath = join(
-				__dirname,
-				`templates/config-template.${templateExtension}`,
-			)
+		if (wasConfigFolderCreated) {
+			consola.debug('Config folder created')
+		}
 
-			consola.debug('Template path:', templatePath)
+		const filePath = join(configFolderPath, `kysely.config.${extension}`)
 
-			await copyFile(templatePath, filePath)
+		consola.debug('File path:', filePath)
 
-			consola.success(`Config file created at ${filePath}`)
-		},
-	} satisfies CommandDef<typeof args>,
-} satisfies SubCommandsDef
+		const templateExtension = await getTemplateExtension(extension)
+
+		const templatePath = join(
+			__dirname,
+			`templates/config-template.${templateExtension}`,
+		)
+
+		consola.debug('Template path:', templatePath)
+
+		await copyFile(templatePath, filePath)
+
+		consola.success(`Config file created at ${filePath}`)
+	},
+})
+
+export const InitCommand = createSubcommand('init', Command)

--- a/src/commands/migrate/down.mts
+++ b/src/commands/migrate/down.mts
@@ -1,4 +1,3 @@
-import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { CommonArgs } from '../../arguments/common.mjs'
 import { MigrateArgs } from '../../arguments/migrate.mjs'
@@ -7,19 +6,19 @@ import { isWrongDirection } from '../../kysely/is-wrong-direction.mjs'
 import { processMigrationResultSet } from '../../kysely/process-migration-result-set.mjs'
 import { usingMigrator } from '../../kysely/using-migrator.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { defineArgs } from '../../utils/define-args.mjs'
+import { defineCommand } from '../../utils/define-command.mjs'
 
-const args = {
+const args = defineArgs({
 	...CommonArgs,
 	...MigrateArgs,
 	...createMigrationNameArg(),
-} satisfies ArgsDef
+})
 
-const BaseDownCommand = {
+const Command = defineCommand(args, {
 	meta: {
-		name: 'down',
 		description: 'Undo the last/specified migration that was run',
 	},
-	args,
 	async run(context) {
 		const { args } = context
 		const { migration_name } = context.args
@@ -42,10 +41,7 @@ const BaseDownCommand = {
 			await processMigrationResultSet(resultSet, 'down', migrator)
 		})
 	},
-} satisfies CommandDef<typeof args>
+})
 
-export const DownCommand = createSubcommand('down', BaseDownCommand)
-export const LegacyDownCommand = createSubcommand(
-	'migrate:down',
-	BaseDownCommand,
-)
+export const DownCommand = createSubcommand('down', Command)
+export const LegacyDownCommand = createSubcommand('migrate:down', Command)

--- a/src/commands/migrate/latest.mts
+++ b/src/commands/migrate/latest.mts
@@ -1,22 +1,18 @@
-import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { CommonArgs } from '../../arguments/common.mjs'
 import { MigrateArgs } from '../../arguments/migrate.mjs'
 import { processMigrationResultSet } from '../../kysely/process-migration-result-set.mjs'
 import { usingMigrator } from '../../kysely/using-migrator.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { defineArgs } from '../../utils/define-args.mjs'
+import { defineCommand } from '../../utils/define-command.mjs'
 
-const args = {
-	...CommonArgs,
-	...MigrateArgs,
-} satisfies ArgsDef
+const args = defineArgs({ ...CommonArgs, ...MigrateArgs })
 
-const BaseLatestCommand = {
+const Command = defineCommand(args, {
 	meta: {
-		name: 'latest',
 		description: 'Update the database schema to the latest version',
 	},
-	args,
 	async run(context) {
 		consola.debug(context, [])
 
@@ -28,10 +24,7 @@ const BaseLatestCommand = {
 			await processMigrationResultSet(resultSet, 'up', migrator)
 		})
 	},
-} satisfies CommandDef<typeof args>
+})
 
-export const LatestCommand = createSubcommand('latest', BaseLatestCommand)
-export const LegacyLatestCommand = createSubcommand(
-	'migrate:latest',
-	BaseLatestCommand,
-)
+export const LatestCommand = createSubcommand('latest', Command)
+export const LegacyLatestCommand = createSubcommand('migrate:latest', Command)

--- a/src/commands/migrate/list.mts
+++ b/src/commands/migrate/list.mts
@@ -1,26 +1,25 @@
-import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { CommonArgs } from '../../arguments/common.mjs'
 import { getMigrations } from '../../kysely/get-migrations.mjs'
 import { usingMigrator } from '../../kysely/using-migrator.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { defineArgs } from '../../utils/define-args.mjs'
+import { defineCommand } from '../../utils/define-command.mjs'
 import { exitWithError } from '../../utils/error.mjs'
 
-const args = {
+const args = defineArgs({
 	...CommonArgs,
 	'fail-on-pending': {
-		type: 'boolean',
 		default: false,
-		required: false,
+		description: 'Fail if there are pending migrations',
+		type: 'boolean',
 	},
-} satisfies ArgsDef
+})
 
-const BaseListCommand = {
+const Command = defineCommand(args, {
 	meta: {
-		name: 'list',
 		description: 'List both completed and pending migrations',
 	},
-	args,
 	async run(context) {
 		consola.debug(context, [])
 
@@ -52,10 +51,7 @@ const BaseListCommand = {
 			exitWithError('Failed due to pending migrations.')
 		}
 	},
-} satisfies CommandDef<typeof args>
+})
 
-export const ListCommand = createSubcommand('list', BaseListCommand)
-export const LegacyListCommand = createSubcommand(
-	'migrate:list',
-	BaseListCommand,
-)
+export const ListCommand = createSubcommand('list', Command)
+export const LegacyListCommand = createSubcommand('migrate:list', Command)

--- a/src/commands/migrate/make.mts
+++ b/src/commands/migrate/make.mts
@@ -1,5 +1,4 @@
 import { copyFile, mkdir } from 'node:fs/promises'
-import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { join } from 'pathe'
 import { CommonArgs } from '../../arguments/common.mjs'
@@ -7,19 +6,20 @@ import { assertExtension, ExtensionArg } from '../../arguments/extension.mjs'
 import { createMigrationNameArg } from '../../arguments/migration-name.mjs'
 import { getConfigOrFail } from '../../config/get-config.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { defineArgs } from '../../utils/define-args.mjs'
+import { defineCommand } from '../../utils/define-command.mjs'
 import { getTemplateExtension } from '../../utils/get-template-extension.mjs'
 
-const args = {
+const args = defineArgs({
 	...CommonArgs,
 	...createMigrationNameArg(true),
 	...ExtensionArg,
-} satisfies ArgsDef
+})
 
-const BaseMakeCommand = {
+const Command = defineCommand(args, {
 	meta: {
 		description: 'Create a new migration file',
 	},
-	args,
 	async run(context) {
 		const { args } = context
 		const { extension } = args
@@ -63,10 +63,7 @@ const BaseMakeCommand = {
 
 		consola.success(`Created migration file at ${filePath}`)
 	},
-} satisfies CommandDef<typeof args>
+})
 
-export const MakeCommand = createSubcommand('make', BaseMakeCommand)
-export const LegacyMakeCommand = createSubcommand(
-	'migrate:make',
-	BaseMakeCommand,
-)
+export const MakeCommand = createSubcommand('make', Command)
+export const LegacyMakeCommand = createSubcommand('migrate:make', Command)

--- a/src/commands/migrate/rollback.mts
+++ b/src/commands/migrate/rollback.mts
@@ -1,4 +1,3 @@
-import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { NO_MIGRATIONS } from 'kysely'
 import { CommonArgs } from '../../arguments/common.mjs'
@@ -6,23 +5,24 @@ import { MigrateArgs } from '../../arguments/migrate.mjs'
 import { processMigrationResultSet } from '../../kysely/process-migration-result-set.mjs'
 import { usingMigrator } from '../../kysely/using-migrator.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { defineArgs } from '../../utils/define-args.mjs'
+import { defineCommand } from '../../utils/define-command.mjs'
 
-const args = {
+const args = defineArgs({
+	...CommonArgs,
+	...MigrateArgs,
 	all: {
 		description: 'Rollback all completed migrations',
 		required: true, // remove this if and when Migrator supports migration batches.
 		type: 'boolean',
 	},
-	...CommonArgs,
-	...MigrateArgs,
-} satisfies ArgsDef
+})
 
-const BaseRollbackCommand = {
+const Command = defineCommand(args, {
 	meta: {
 		name: 'rollback',
 		description: 'Rollback all the completed migrations',
 	},
-	args,
 	async run(context) {
 		consola.debug(context, [])
 
@@ -34,10 +34,10 @@ const BaseRollbackCommand = {
 			await processMigrationResultSet(resultSet, 'down', migrator)
 		})
 	},
-} satisfies CommandDef<typeof args>
+})
 
-export const RollbackCommand = createSubcommand('rollback', BaseRollbackCommand)
+export const RollbackCommand = createSubcommand('rollback', Command)
 export const LegacyRollbackCommand = createSubcommand(
 	'migrate:rollback',
-	BaseRollbackCommand,
+	Command,
 )

--- a/src/commands/migrate/rollback.mts
+++ b/src/commands/migrate/rollback.mts
@@ -20,7 +20,6 @@ const args = defineArgs({
 
 const Command = defineCommand(args, {
 	meta: {
-		name: 'rollback',
 		description: 'Rollback all the completed migrations',
 	},
 	async run(context) {

--- a/src/commands/migrate/root.mts
+++ b/src/commands/migrate/root.mts
@@ -1,6 +1,6 @@
-import { type SubCommandsDef, showUsage } from 'citty'
+import { showUsage } from 'citty'
 import { consola } from 'consola'
-import { CommonArgs } from '../../arguments/common.mjs'
+import { createSubcommand } from '../../utils/create-subcommand.mjs'
 import { isInSubcommand } from '../../utils/is-in-subcommand.mjs'
 import { RootCommand } from '../root.mjs'
 import { DownCommand } from './down.mjs'
@@ -10,27 +10,24 @@ import { MakeCommand } from './make.mjs'
 import { RollbackCommand } from './rollback.mjs'
 import { UpCommand } from './up.mjs'
 
-export const MigrateCommand = {
-	migrate: {
-		meta: {
-			name: 'migrate',
-			description: 'Migrate the database schema',
-		},
-		args: CommonArgs,
-		subCommands: {
-			...DownCommand,
-			...LatestCommand,
-			...ListCommand,
-			...MakeCommand,
-			...RollbackCommand,
-			...UpCommand,
-		},
-		async run(context) {
-			if (!isInSubcommand(context)) {
-				consola.debug(context, [])
-
-				await showUsage(context.cmd, RootCommand)
-			}
-		},
+export const MigrateCommand = createSubcommand('migrate', {
+	args: {},
+	meta: {
+		description: 'Migrate the database schema',
 	},
-} satisfies SubCommandsDef
+	subCommands: {
+		...DownCommand,
+		...LatestCommand,
+		...ListCommand,
+		...MakeCommand,
+		...RollbackCommand,
+		...UpCommand,
+	},
+	async run(context) {
+		if (!isInSubcommand(context)) {
+			consola.debug(context, [])
+
+			await showUsage(context.cmd, RootCommand)
+		}
+	},
+})

--- a/src/commands/migrate/root.mts
+++ b/src/commands/migrate/root.mts
@@ -1,6 +1,7 @@
 import { showUsage } from 'citty'
 import { consola } from 'consola'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import type { StrictCommandDef } from '../../utils/define-command.mjs'
 import { isInSubcommand } from '../../utils/is-in-subcommand.mjs'
 import { RootCommand } from '../root.mjs'
 import { DownCommand } from './down.mjs'
@@ -10,18 +11,20 @@ import { MakeCommand } from './make.mjs'
 import { RollbackCommand } from './rollback.mjs'
 import { UpCommand } from './up.mjs'
 
+const subCommands = {
+	...DownCommand,
+	...LatestCommand,
+	...ListCommand,
+	...MakeCommand,
+	...RollbackCommand,
+	...UpCommand,
+	// biome-ignore lint/suspicious/noExplicitAny: it's fine
+} satisfies StrictCommandDef<any>['subCommands']
+
 export const MigrateCommand = createSubcommand('migrate', {
 	args: {},
 	meta: {
-		description: 'Migrate the database schema',
-	},
-	subCommands: {
-		...DownCommand,
-		...LatestCommand,
-		...ListCommand,
-		...MakeCommand,
-		...RollbackCommand,
-		...UpCommand,
+		description: `\`${Object.keys(subCommands).sort().join('|')}\``,
 	},
 	async run(context) {
 		if (!isInSubcommand(context)) {
@@ -30,4 +33,5 @@ export const MigrateCommand = createSubcommand('migrate', {
 			await showUsage(context.cmd, RootCommand)
 		}
 	},
+	subCommands,
 })

--- a/src/commands/migrate/up.mts
+++ b/src/commands/migrate/up.mts
@@ -1,4 +1,3 @@
-import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { CommonArgs } from '../../arguments/common.mjs'
 import { MigrateArgs } from '../../arguments/migrate.mjs'
@@ -7,19 +6,19 @@ import { isWrongDirection } from '../../kysely/is-wrong-direction.mjs'
 import { processMigrationResultSet } from '../../kysely/process-migration-result-set.mjs'
 import { usingMigrator } from '../../kysely/using-migrator.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { defineArgs } from '../../utils/define-args.mjs'
+import { defineCommand } from '../../utils/define-command.mjs'
 
-const args = {
+const args = defineArgs({
 	...CommonArgs,
 	...MigrateArgs,
 	...createMigrationNameArg(),
-} satisfies ArgsDef
+})
 
-const BaseUpCommand = {
+const Command = defineCommand(args, {
 	meta: {
-		name: 'up',
 		description: 'Run the next migration that has not yet been run',
 	},
-	args,
 	async run(context) {
 		const { args } = context
 		const { migration_name } = args
@@ -42,7 +41,7 @@ const BaseUpCommand = {
 			await processMigrationResultSet(resultSet, 'up', migrator)
 		})
 	},
-} satisfies CommandDef<typeof args>
+})
 
-export const UpCommand = createSubcommand('up', BaseUpCommand)
-export const LegacyUpCommand = createSubcommand('migrate:up', BaseUpCommand)
+export const UpCommand = createSubcommand('up', Command)
+export const LegacyUpCommand = createSubcommand('migrate:up', Command)

--- a/src/commands/root.mts
+++ b/src/commands/root.mts
@@ -1,7 +1,8 @@
-import { type ArgsDef, type CommandDef, showUsage } from 'citty'
+import { showUsage } from 'citty'
 import { consola, LogLevels } from 'consola'
-import { CommonArgs } from '../arguments/common.mjs'
 import { getCWD } from '../config/get-cwd.mjs'
+import { defineArgs } from '../utils/define-args.mjs'
+import { defineCommand } from '../utils/define-command.mjs'
 import { isInSubcommand } from '../utils/is-in-subcommand.mjs'
 import {
 	printInstalledVersions,
@@ -20,22 +21,26 @@ import { SeedCommand } from './seed/root.mjs'
 import { LegacyRunCommand } from './seed/run.mjs'
 import { SqlCommand } from './sql.mjs'
 
-const args = {
-	...CommonArgs,
+const args = defineArgs({
+	help: {
+		alias: 'h',
+		default: false,
+		description: 'Show help information',
+		type: 'boolean',
+	},
 	version: {
 		alias: 'v',
 		default: false,
 		description: 'Show version number',
 		type: 'boolean',
 	},
-} satisfies ArgsDef
+})
 
-export const RootCommand = {
+export const RootCommand = defineCommand(args, {
 	meta: {
 		name: 'kysely',
 		description: 'A command-line tool for Kysely',
 	},
-	args,
 	subCommands: {
 		...InitCommand,
 		...LegacyDownCommand,
@@ -59,7 +64,7 @@ export const RootCommand = {
 
 		consola.options.formatOptions.date = false
 
-		consola.debug('cwd', getCWD(args)) // ensures the CWD is set
+		consola.debug('cwd', getCWD(args as never)) // ensures the CWD is set
 	},
 	async run(context) {
 		const { args } = context
@@ -68,18 +73,18 @@ export const RootCommand = {
 			consola.debug(context, [])
 
 			if (args.version) {
-				return await printInstalledVersions(args)
+				return await printInstalledVersions(args as never)
 			}
 
 			await showUsage(context.cmd)
 		}
 
 		try {
-			await printUpgradeNotice(args)
+			await printUpgradeNotice(args as never)
 		} catch (error) {
 			consola.debug('Failed to print upgrade notice:', error)
 		}
 
 		consola.debug(`finished running from "${__filename}"`)
 	},
-} satisfies CommandDef<typeof args>
+})

--- a/src/commands/seed/list.mts
+++ b/src/commands/seed/list.mts
@@ -1,37 +1,30 @@
-import type { ArgsDef, CommandDef, SubCommandsDef } from 'citty'
 import { consola } from 'consola'
 import { CommonArgs } from '../../arguments/common.mjs'
 import { usingSeeder } from '../../seeds/using-seeder.mjs'
+import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { defineCommand } from '../../utils/define-command.mjs'
 
-const args = {
-	...CommonArgs,
-} satisfies ArgsDef
+const Command = defineCommand(CommonArgs, {
+	meta: {
+		description: 'List seeds',
+	},
+	async run(context) {
+		consola.debug(context, [])
 
-export const ListCommand = {
-	list: {
-		meta: {
-			name: 'list',
-			description: 'List seeds',
-		},
-		args,
-		async run(context) {
-			consola.debug(context, [])
+		const seeds = await usingSeeder(context.args, (seeder) => seeder.getSeeds())
 
-			const seeds = await usingSeeder(context.args, (seeder) =>
-				seeder.getSeeds(),
-			)
+		consola.debug(seeds)
 
-			consola.debug(seeds)
+		if (!seeds.length) {
+			return consola.info('No seeds found.')
+		}
 
-			if (!seeds.length) {
-				return consola.info('No seeds found.')
-			}
+		consola.info(`Found ${seeds.length} seed${seeds.length > 1 ? 's' : ''}:`)
 
-			consola.info(`Found ${seeds.length} seed${seeds.length > 1 ? 's' : ''}:`)
+		for (const seed of seeds) {
+			consola.log(seed.name)
+		}
+	},
+})
 
-			for (const seed of seeds) {
-				consola.log(seed.name)
-			}
-		},
-	} satisfies CommandDef<typeof args>,
-} satisfies SubCommandsDef
+export const ListCommand = createSubcommand('list', Command)

--- a/src/commands/seed/make.mts
+++ b/src/commands/seed/make.mts
@@ -1,14 +1,15 @@
 import { copyFile, mkdir } from 'node:fs/promises'
-import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { join } from 'pathe'
 import { CommonArgs } from '../../arguments/common.mjs'
 import { assertExtension, ExtensionArg } from '../../arguments/extension.mjs'
 import { getConfigOrFail } from '../../config/get-config.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { defineArgs } from '../../utils/define-args.mjs'
+import { defineCommand } from '../../utils/define-command.mjs'
 import { getTemplateExtension } from '../../utils/get-template-extension.mjs'
 
-const args = {
+const args = defineArgs({
 	...CommonArgs,
 	...ExtensionArg,
 	seed_name: {
@@ -16,13 +17,12 @@ const args = {
 		required: true,
 		type: 'positional',
 	},
-} satisfies ArgsDef
+})
 
-const BaseMakeCommand = {
+const Command = defineCommand(args, {
 	meta: {
 		description: 'Create a new seed file',
 	},
-	args,
 	async run(context) {
 		const { args } = context
 		const { extension } = args
@@ -64,7 +64,7 @@ const BaseMakeCommand = {
 
 		consola.success(`Created seed file at ${filePath}`)
 	},
-} satisfies CommandDef<typeof args>
+})
 
-export const MakeCommand = createSubcommand('make', BaseMakeCommand)
-export const LegacyMakeCommand = createSubcommand('seed:make', BaseMakeCommand)
+export const MakeCommand = createSubcommand('make', Command)
+export const LegacyMakeCommand = createSubcommand('seed:make', Command)

--- a/src/commands/seed/root.mts
+++ b/src/commands/seed/root.mts
@@ -1,31 +1,28 @@
-import { type SubCommandsDef, showUsage } from 'citty'
+import { showUsage } from 'citty'
 import { consola } from 'consola'
-import { CommonArgs } from '../../arguments/common.mjs'
+import { createSubcommand } from '../../utils/create-subcommand.mjs'
 import { isInSubcommand } from '../../utils/is-in-subcommand.mjs'
 import { RootCommand } from '../root.mjs'
 import { ListCommand } from './list.mjs'
 import { MakeCommand } from './make.mjs'
 import { RunCommand } from './run.mjs'
 
-export const SeedCommand = {
-	seed: {
-		meta: {
-			name: 'seed',
-			description:
-				'Populate your database with test or seed data independent of your migration files',
-		},
-		args: CommonArgs,
-		subCommands: {
-			...ListCommand,
-			...MakeCommand,
-			...RunCommand,
-		},
-		async run(context) {
-			if (!isInSubcommand(context)) {
-				consola.debug(context, [])
-
-				await showUsage(context.cmd, RootCommand)
-			}
-		},
+export const SeedCommand = createSubcommand('seed', {
+	args: {},
+	meta: {
+		description:
+			'Populate your database with test or seed data independent of your migration files',
 	},
-} satisfies SubCommandsDef
+	subCommands: {
+		...ListCommand,
+		...MakeCommand,
+		...RunCommand,
+	},
+	async run(context) {
+		if (!isInSubcommand(context)) {
+			consola.debug(context, [])
+
+			await showUsage(context.cmd, RootCommand)
+		}
+	},
+})

--- a/src/commands/seed/root.mts
+++ b/src/commands/seed/root.mts
@@ -1,22 +1,24 @@
 import { showUsage } from 'citty'
 import { consola } from 'consola'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import type { StrictCommandDef } from '../../utils/define-command.mjs'
 import { isInSubcommand } from '../../utils/is-in-subcommand.mjs'
 import { RootCommand } from '../root.mjs'
 import { ListCommand } from './list.mjs'
 import { MakeCommand } from './make.mjs'
 import { RunCommand } from './run.mjs'
 
+const subCommands = {
+	...ListCommand,
+	...MakeCommand,
+	...RunCommand,
+	// biome-ignore lint/suspicious/noExplicitAny: it's fine
+} satisfies StrictCommandDef<any>['subCommands']
+
 export const SeedCommand = createSubcommand('seed', {
 	args: {},
 	meta: {
-		description:
-			'Populate your database with test or seed data independent of your migration files',
-	},
-	subCommands: {
-		...ListCommand,
-		...MakeCommand,
-		...RunCommand,
+		description: `\`${Object.keys(subCommands).sort().join('|')}\``,
 	},
 	async run(context) {
 		if (!isInSubcommand(context)) {
@@ -25,4 +27,5 @@ export const SeedCommand = createSubcommand('seed', {
 			await showUsage(context.cmd, RootCommand)
 		}
 	},
+	subCommands,
 })

--- a/src/commands/seed/run.mts
+++ b/src/commands/seed/run.mts
@@ -1,25 +1,24 @@
-import type { ArgsDef, CommandDef } from 'citty'
 import { consola } from 'consola'
 import { colorize } from 'consola/utils'
 import { CommonArgs } from '../../arguments/common.mjs'
 import { usingSeeder } from '../../seeds/using-seeder.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
+import { defineArgs } from '../../utils/define-args.mjs'
+import { defineCommand } from '../../utils/define-command.mjs'
 import { exitWithError } from '../../utils/error.mjs'
 
-const args = {
+const args = defineArgs({
 	...CommonArgs,
 	specific: {
 		description: 'Run seed file/s with given name/s',
 		type: 'string',
 	},
-} satisfies ArgsDef
+})
 
-const BaseRunCommand = {
+const Command = defineCommand(args, {
 	meta: {
 		description: 'Run seed files',
-		name: 'run',
 	},
-	args,
 	async run(context) {
 		const { args } = context
 		const { specific } = args
@@ -68,7 +67,7 @@ const BaseRunCommand = {
 			exitWithError(error)
 		}
 	},
-} satisfies CommandDef<typeof args>
+})
 
-export const RunCommand = createSubcommand('run', BaseRunCommand)
-export const LegacyRunCommand = createSubcommand('seed:run', BaseRunCommand)
+export const RunCommand = createSubcommand('run', Command)
+export const LegacyRunCommand = createSubcommand('seed:run', Command)

--- a/src/config/define-config.mts
+++ b/src/config/define-config.mts
@@ -2,8 +2,13 @@ import type { C12InputConfig } from 'c12'
 import type { PartialDeep } from 'type-fest'
 import type { KyselyCTLConfig } from './kysely-ctl-config.mjs'
 
-export type DefineConfigInput = KyselyCTLConfig &
-	C12InputConfig<PartialDeep<KyselyCTLConfig>>
+type PartialKyselyCTLConfig = PartialDeep<KyselyCTLConfig>
+
+export type DefineConfigInput = (
+	| (PartialKyselyCTLConfig & { extends: string | string[] })
+	| (KyselyCTLConfig & { extends?: never })
+) &
+	C12InputConfig<PartialKyselyCTLConfig>
 
 export const defineConfig = (input: DefineConfigInput): DefineConfigInput =>
 	input

--- a/src/config/get-config.mts
+++ b/src/config/get-config.mts
@@ -117,15 +117,16 @@ export function configFileExists(
 	return configFile !== undefined && configFile !== 'kysely.config'
 }
 
+const BASE_CONFIG_FILESNAMES = ALL_EXTENSIONS.flatMap((extension) => [
+	`.config/kysely.config.${extension}`,
+	`kysely.config.${extension}`,
+])
+
 async function findNearestKyselyConfigPath(): Promise<string | null> {
 	try {
-		const kyselyConfigPath = await findNearestFile(
-			ALL_EXTENSIONS.flatMap((extension) => [
-				`.config/kysely.config.${extension}`,
-				`kysely.config.${extension}`,
-			]),
-			{ startingFrom: getCWD() },
-		)
+		const kyselyConfigPath = await findNearestFile(BASE_CONFIG_FILESNAMES, {
+			startingFrom: getCWD(),
+		})
 
 		consola.debug('found kysely config file at', kyselyConfigPath)
 

--- a/src/utils/create-subcommand.mts
+++ b/src/utils/create-subcommand.mts
@@ -1,17 +1,21 @@
-import type { CommandDef, SubCommandsDef } from 'citty'
+import type { SubCommandsDef } from 'citty'
+import type { StrictCommandDef } from './define-command.mjs'
 
 export function createSubcommand<
 	Name extends string,
-	Command extends { meta: CommandDef['meta'] },
->(name: Name, def: Command): { [K in Name]: Command } {
+	// biome-ignore lint/suspicious/noExplicitAny: it's fine.
+	const Command extends StrictCommandDef<any>,
+>(
+	name: Name,
+	def: Command,
+): {
+	readonly [K in Name]: Readonly<
+		Omit<Command, 'meta'> & {
+			meta: Omit<Command['meta'], 'name'> & { readonly name: Name }
+		}
+	>
+} {
 	return {
-		[name]: {
-			...def,
-			meta: {
-				...def.meta,
-				name,
-			},
-		},
-		// biome-ignore lint/suspicious/noExplicitAny: this is perfectly fine
-	} satisfies SubCommandsDef as any
+		[name]: { ...def, meta: { ...def.meta, name } },
+	} satisfies SubCommandsDef as never
 }

--- a/src/utils/define-args.mts
+++ b/src/utils/define-args.mts
@@ -1,0 +1,48 @@
+import type { ArgDef, PositionalArgDef } from 'citty'
+
+export type StrictArgsDef = Record<string, StrictArgDef>
+
+export type StrictArgDef = ArgDef & {
+	description: NonNullable<ArgDef['description']>
+	type: NonNullable<ArgDef['type']>
+}
+
+export function defineArgs<const Args extends StrictArgsDef>(
+	args: Args,
+	dontSort?: boolean,
+): Args {
+	return dontSort ? args : (sortArgs(args) as Args)
+}
+
+function sortArgs(args: StrictArgsDef): StrictArgsDef {
+	return Object.fromEntries(
+		Object.entries(args).sort(([nameA, argA], [nameB, argB]) => {
+			const aliasA = getAlias(argA)
+			const aliasB = getAlias(argB)
+
+			if (aliasA) {
+				nameA = aliasA
+			}
+
+			if (aliasB) {
+				nameB = aliasB
+			}
+
+			return nameA.localeCompare(nameB)
+		}),
+	)
+}
+
+function getAlias(arg: StrictArgDef): string | null {
+	const { alias } = arg as Exclude<ArgDef, PositionalArgDef>
+
+	if (!alias) {
+		return null
+	}
+
+	if (Array.isArray(alias)) {
+		return alias.at(0) || null
+	}
+
+	return alias
+}

--- a/src/utils/define-command.mts
+++ b/src/utils/define-command.mts
@@ -1,0 +1,24 @@
+import type { CommandContext, CommandDef, CommandMeta, Resolvable } from 'citty'
+import type { StrictArgsDef } from './define-args.mjs'
+
+export type StrictCommandDef<Args extends StrictArgsDef> = Omit<
+	CommandDef<Args>,
+	'cleanup' | 'meta' | 'run' | 'setup'
+> & {
+	args: Resolvable<Args>
+	cleanup?(context: CommandContext<Args>): void | Promise<void>
+	meta: Resolvable<
+		Omit<CommandMeta, 'description'> & {
+			description: NonNullable<CommandMeta['description']>
+		}
+	>
+	run(context: CommandContext<Args>): void | Promise<void>
+	setup?(context: CommandContext<Args>): void | Promise<void>
+}
+
+export function defineCommand<
+	Args extends StrictArgsDef,
+	const Command extends Omit<StrictCommandDef<Args>, 'args'> & { args?: never },
+>(args: Args, command: Command): Command & { args: Args } {
+	return { ...command, args }
+}

--- a/src/utils/define-command.mts
+++ b/src/utils/define-command.mts
@@ -20,5 +20,25 @@ export function defineCommand<
 	Args extends StrictArgsDef,
 	const Command extends Omit<StrictCommandDef<Args>, 'args'> & { args?: never },
 >(args: Args, command: Command): Command & { args: Args } {
-	return { ...command, args }
+	return {
+		...command,
+		args,
+		subCommands: sortSubCommands(command.subCommands),
+	}
+}
+
+function sortSubCommands(
+	// biome-ignore lint/suspicious/noExplicitAny: it's fine
+	subCommands: StrictCommandDef<any>['subCommands'],
+	// biome-ignore lint/suspicious/noExplicitAny: it's fine
+): StrictCommandDef<any>['subCommands'] {
+	if (!subCommands) {
+		return
+	}
+
+	return Object.fromEntries(
+		Object.entries(subCommands).sort(([nameA], [nameB]) =>
+			nameA.localeCompare(nameB),
+		),
+	)
 }

--- a/src/utils/version.mts
+++ b/src/utils/version.mts
@@ -131,11 +131,11 @@ export async function printUpgradeNotice(
 
 	const installLocallyCommand = (
 		{
-			bun: (name, dev) => `add ${dev ? '-D ' : ''}${name}@latest`,
-			deno: (name, dev) => `install ${dev ? '-D ' : ''}npm:${name}@latest`,
-			npm: (name, dev) => `i ${dev ? '-D ' : ''}${name}@latest`,
-			pnpm: (name, dev) => `add ${dev ? '-D ' : ''}${name}@latest`,
-			yarn: (name, dev) => `add ${dev ? '-D ' : ''}${name}@latest`,
+			bun: (name, dev?) => `add ${dev ? '-D ' : ''}${name}@latest`,
+			deno: (name, dev?) => `install ${dev ? '-D ' : ''}npm:${name}@latest`,
+			npm: (name, dev?) => `i ${dev ? '-D ' : ''}${name}@latest`,
+			pnpm: (name, dev?) => `add ${dev ? '-D ' : ''}${name}@latest`,
+			yarn: (name, dev?) => `add ${dev ? '-D ' : ''}${name}@latest`,
 		} satisfies Record<
 			PackageManagerName,
 			(name: string, dev?: boolean) => string


### PR DESCRIPTION
Hey 👋 

closes #209.

This PR adds the `-c`/`--config` flag that allows you to override config search and instead point to a specific path to be loaded.

It also adds `extends` config property support. You can extend other configs by providing their path/s, the same way you normally would with `tsconfig` files. This is experimental and will probably bug out in some scenarios I haven't thought about yet - please report any issues.