### PR TITLE
fix: `kysely sql` non-global regex error

### DIFF
--- a/src/kysely/infer-dialect-name.mts
+++ b/src/kysely/infer-dialect-name.mts
@@ -1,6 +1,6 @@
 import type { Kysely } from 'kysely'
 
-const CAPTURE_COMMON_CLASS_SUFFIXES = /adapter|dialect/i
+const CAPTURE_COMMON_CLASS_SUFFIXES = /adapter|dialect/gi
 
 export function inferDialectName(kysely: Kysely<unknown>): string {
 	return kysely


### PR DESCRIPTION
This PR fixes the following error when running `kysely sql`:


```
String.prototype.replaceAll called with a non-global RegExp argument
```