### PR TITLE
fix: ensure migrate:make respects destroyOnExit config

### DIFF
--- a/src/commands/migrate/make.mts
+++ b/src/commands/migrate/make.mts
@@ -5,6 +5,7 @@ import { CommonArgs } from '../../arguments/common.mjs'
 import { assertExtension, ExtensionArg } from '../../arguments/extension.mjs'
 import { createMigrationNameArg } from '../../arguments/migration-name.mjs'
 import { getConfigOrFail } from '../../config/get-config.mjs'
+import { usingKysely } from '../../kysely/using-kysely.mjs'
 import { createSubcommand } from '../../utils/create-subcommand.mjs'
 import { defineArgs } from '../../utils/define-args.mjs'
 import { defineCommand } from '../../utils/define-command.mjs'
@@ -26,40 +27,42 @@ const Command = defineCommand(args, {
 
 		const config = await getConfigOrFail(args)
 
-		assertExtension(extension, config, 'migrations')
+		await usingKysely(config, async () => {
+			assertExtension(extension, config, 'migrations')
 
-		const { getMigrationPrefix, migrationFolder } = config.migrations
+			const { getMigrationPrefix, migrationFolder } = config.migrations
 
-		const wasMigrationsFolderCreated = Boolean(
-			await mkdir(migrationFolder, { recursive: true }),
-		)
+			const wasMigrationsFolderCreated = Boolean(
+				await mkdir(migrationFolder, { recursive: true }),
+			)
 
-		if (wasMigrationsFolderCreated) {
-			consola.debug('Migrations folder created')
-		}
+			if (wasMigrationsFolderCreated) {
+				consola.debug('Migrations folder created')
+			}
 
-		const filename = `${await getMigrationPrefix()}${
-			args.migration_name
-		}.${extension}`
+			const filename = `${await getMigrationPrefix()}${
+				args.migration_name
+			}.${extension}`
 
-		consola.debug('Filename:', filename)
+			consola.debug('Filename:', filename)
 
-		const filePath = join(migrationFolder, filename)
+			const filePath = join(migrationFolder, filename)
 
-		consola.debug('File path:', filePath)
+			consola.debug('File path:', filePath)
 
-		const templateExtension = await getTemplateExtension(extension)
+			const templateExtension = await getTemplateExtension(extension)
 
-		const templatePath = join(
-			__dirname,
-			`templates/migration-template.${templateExtension}`,
-		)
+			const templatePath = join(
+				__dirname,
+				`templates/migration-template.${templateExtension}`,
+			)
 
-		consola.debug('Template path:', templatePath)
+			consola.debug('Template path:', templatePath)
 
-		await copyFile(templatePath, filePath)
+			await copyFile(templatePath, filePath)
 
-		consola.success(`Created migration file at ${filePath}`)
+			consola.success(`Created migration file at ${filePath}`)
+		})
 	},
 })
 


### PR DESCRIPTION
## Summary

- When passing a pre-configured `Kysely` instance via `kysely` config option, `migrate:make` command would not destroy the instance after execution
- This causes the process to hang when connection pool settings like `maxIdle` create persistent connections
- Other commands like `migrate:up`, `migrate:down`, `migrate:list` already use `usingKysely()` wrapper which handles cleanup

## Root Cause

The `MakeCommand` implementation directly called `getConfigOrFail()` and then proceeded to create the migration file without wrapping execution in `usingKysely()`. This skipped the `destroyOnExit` cleanup logic.

## Fix

Wrap the `migrate:make` command execution in `usingKysely()` to ensure `destroyOnExit` logic is applied consistently with other commands.

```typescript
// Before
const config = await getConfigOrFail(args)
// ... create migration file

// After  
await usingKysely(config, async () => {
  // ... create migration file
})
```

## Testing

- All 67 existing tests pass
- Build completes successfully

## Related

Addresses issue where `migrate:make` hangs after creating migration file when using connection pool settings like `maxIdle=2` in database URL.