### PR TITLE
feat: support `kysely`>=0.29.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,21 @@ jobs:
   node:
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 25]
         os: [macos-latest, ubuntu-latest, windows-latest]
-        type: [cjs, esm, esm-multi-config, esm-tsconfig-paths, esm-tsconfig-paths-inherited, esm-tsconfig-paths-no-baseurl, esm-top-level-await, esm-environments, esm-jsx]
+        type:
+          [
+            cjs,
+            esm,
+            esm-multi-config,
+            esm-tsconfig-paths,
+            esm-tsconfig-paths-inherited,
+            esm-tsconfig-paths-no-baseurl,
+            esm-top-level-await,
+            esm-environments,
+            esm-jsx,
+            esm-kysely@0.28.17,
+          ]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/examples/node-esm-kysely@0.28.17/.config/kysely.config.ts
+++ b/examples/node-esm-kysely@0.28.17/.config/kysely.config.ts
@@ -1,0 +1,16 @@
+import { equal } from 'node:assert'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import database from 'better-sqlite3'
+import { defineConfig } from 'kysely-ctl'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+equal(process.env.ENABLE_LOGS, '1', 'envars not loaded as expected')
+
+export default defineConfig({
+	dialect: 'better-sqlite3',
+	dialectConfig: {
+		database: database(resolve(__dirname, '../example.db')),
+	},
+})

--- a/examples/node-esm-kysely@0.28.17/.env
+++ b/examples/node-esm-kysely@0.28.17/.env
@@ -1,0 +1,1 @@
+ENABLE_LOGS=1

--- a/examples/node-esm-kysely@0.28.17/migrations/1716743937856_add_table_moshe.ts
+++ b/examples/node-esm-kysely@0.28.17/migrations/1716743937856_add_table_moshe.ts
@@ -1,0 +1,12 @@
+import { equal } from 'node:assert'
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	equal(process.env.ENABLE_LOGS, '1', 'envars not loaded as expected')
+
+	await db.schema.createTable('moshe').addColumn('id', 'integer').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.dropTable('moshe').execute()
+}

--- a/examples/node-esm-kysely@0.28.17/migrations/1716746051776_add_column_is_moshe.ts
+++ b/examples/node-esm-kysely@0.28.17/migrations/1716746051776_add_column_is_moshe.ts
@@ -1,0 +1,9 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.schema.alterTable('moshe').addColumn('is_moshe', 'boolean').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.alterTable('moshe').dropColumn('is_moshe').execute()
+}

--- a/examples/node-esm-kysely@0.28.17/package.json
+++ b/examples/node-esm-kysely@0.28.17/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "node-esm-kysely-0.28.17",
+	"type": "module",
+	"devDependencies": {
+		"@types/better-sqlite3": "catalog:",
+		"kysely-ctl": "link:../.."
+	},
+	"dependencies": {
+		"better-sqlite3": "catalog:",
+		"kysely": "0.28.17"
+	}
+}

--- a/examples/node-esm-kysely@0.28.17/tsconfig.json
+++ b/examples/node-esm-kysely@0.28.17/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": [".config/**/*", "migrations"]
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"tsconfck": "^3.1.6"
 	},
 	"peerDependencies": {
-		"kysely": ">=0.18.1 <0.29.0",
+		"kysely": ">=0.18.1 <0.30.0",
 		"kysely-neon": "^2",
 		"kysely-postgres-js": "^2 || ^3",
 		"kysely-prisma-postgres": "^0.1"
@@ -75,7 +75,7 @@
 		"vitest": "^4.0.16"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22"
 	},
 	"keywords": [
 		"cli",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,18 +6,12 @@ settings:
 
 catalogs:
   default:
-    '@types/better-sqlite3':
-      specifier: 7.6.13
-      version: 7.6.13
     better-sqlite3:
       specifier: 12.6.0
       version: 12.6.0
     kysely:
-      specifier: 0.28.9
-      version: 0.28.9
-    typescript:
-      specifier: 5.9.3
-      version: 5.9.3
+      specifier: 0.29.0
+      version: 0.29.0
 
 importers:
 
@@ -80,16 +74,16 @@ importers:
         version: 12.6.0
       kysely:
         specifier: 'catalog:'
-        version: 0.28.9
+        version: 0.29.0
       kysely-neon:
         specifier: ^2.0.2
-        version: 2.0.2(@neondatabase/serverless@1.0.1)(kysely@0.28.9)
+        version: 2.0.2(@neondatabase/serverless@1.0.1)(kysely@0.29.0)
       kysely-postgres-js:
         specifier: ^3.0.0
-        version: 3.0.0(kysely@0.28.9)(postgres@3.4.8)
+        version: 3.0.0(kysely@0.29.0)(postgres@3.4.8)
       kysely-prisma-postgres:
         specifier: ^0.1.0
-        version: 0.1.0(@prisma/ppg@0.5.2)(kysely@0.28.9)
+        version: 0.1.0(@prisma/ppg@0.5.2)(kysely@0.29.0)
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
@@ -113,7 +107,7 @@ importers:
         version: 12.6.0
       kysely:
         specifier: 'catalog:'
-        version: 0.28.9
+        version: 0.29.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
@@ -129,7 +123,7 @@ importers:
         version: 12.6.0
       kysely:
         specifier: 'catalog:'
-        version: 0.28.9
+        version: 0.29.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
@@ -145,7 +139,7 @@ importers:
         version: 12.6.0
       kysely:
         specifier: 'catalog:'
-        version: 0.28.9
+        version: 0.29.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
@@ -164,7 +158,7 @@ importers:
         version: 12.6.0
       kysely:
         specifier: 'catalog:'
-        version: 0.28.9
+        version: 0.29.0
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -189,7 +183,7 @@ importers:
         version: 12.6.0
       kysely:
         specifier: 'catalog:'
-        version: 0.28.9
+        version: 0.29.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
@@ -205,7 +199,7 @@ importers:
         version: 12.6.0
       kysely:
         specifier: 'catalog:'
-        version: 0.28.9
+        version: 0.29.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
@@ -221,7 +215,7 @@ importers:
         version: 12.6.0
       kysely:
         specifier: 'catalog:'
-        version: 0.28.9
+        version: 0.29.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
@@ -237,7 +231,7 @@ importers:
         version: 12.6.0
       kysely:
         specifier: 'catalog:'
-        version: 0.28.9
+        version: 0.29.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
@@ -256,7 +250,7 @@ importers:
         version: 12.6.0
       kysely:
         specifier: 'catalog:'
-        version: 0.28.9
+        version: 0.29.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: 'catalog:'
@@ -1545,9 +1539,9 @@ packages:
       '@prisma/ppg': ^0.5
       kysely: ^0.28
 
-  kysely@0.28.9:
-    resolution: {integrity: sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==}
-    engines: {node: '>=20.0.0'}
+  kysely@0.29.0:
+    resolution: {integrity: sha512-LrQfPUeTW7MXbMvT62moEMnpMTuj9TO3lqjCeLKjM975PJ4Alrl/43f2tlDX7xOsNptKgH4LSNGwIbXwEkLg4g==}
+    engines: {node: '>=22.0.0'}
 
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
@@ -3396,23 +3390,23 @@ snapshots:
       jsonparse: 1.3.1
       through2: 4.0.2
 
-  kysely-neon@2.0.2(@neondatabase/serverless@1.0.1)(kysely@0.28.9):
+  kysely-neon@2.0.2(@neondatabase/serverless@1.0.1)(kysely@0.29.0):
     dependencies:
       '@neondatabase/serverless': 1.0.1
-      kysely: 0.28.9
+      kysely: 0.29.0
 
-  kysely-postgres-js@3.0.0(kysely@0.28.9)(postgres@3.4.8):
+  kysely-postgres-js@3.0.0(kysely@0.29.0)(postgres@3.4.8):
     dependencies:
-      kysely: 0.28.9
+      kysely: 0.29.0
     optionalDependencies:
       postgres: 3.4.8
 
-  kysely-prisma-postgres@0.1.0(@prisma/ppg@0.5.2)(kysely@0.28.9):
+  kysely-prisma-postgres@0.1.0(@prisma/ppg@0.5.2)(kysely@0.29.0):
     dependencies:
       '@prisma/ppg': 0.5.2
-      kysely: 0.28.9
+      kysely: 0.29.0
 
-  kysely@0.28.9: {}
+  kysely@0.29.0: {}
 
   load-json-file@4.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,18 @@ settings:
 
 catalogs:
   default:
+    '@types/better-sqlite3':
+      specifier: 7.6.13
+      version: 7.6.13
     better-sqlite3:
       specifier: 12.6.0
       version: 12.6.0
     kysely:
       specifier: 0.29.0
       version: 0.29.0
+    typescript:
+      specifier: 5.9.3
+      version: 5.9.3
 
 importers:
 
@@ -172,6 +178,22 @@ importers:
       '@types/react':
         specifier: ^19.2.8
         version: 19.2.8
+      kysely-ctl:
+        specifier: link:../..
+        version: link:../..
+
+  examples/node-esm-kysely@0.28.17:
+    dependencies:
+      better-sqlite3:
+        specifier: 'catalog:'
+        version: 12.6.0
+      kysely:
+        specifier: 0.28.17
+        version: 0.28.17
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: 'catalog:'
+        version: 7.6.13
       kysely-ctl:
         specifier: link:../..
         version: link:../..
@@ -1538,6 +1560,10 @@ packages:
     peerDependencies:
       '@prisma/ppg': ^0.5
       kysely: ^0.28
+
+  kysely@0.28.17:
+    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
+    engines: {node: '>=20.0.0'}
 
   kysely@0.29.0:
     resolution: {integrity: sha512-LrQfPUeTW7MXbMvT62moEMnpMTuj9TO3lqjCeLKjM975PJ4Alrl/43f2tlDX7xOsNptKgH4LSNGwIbXwEkLg4g==}
@@ -3405,6 +3431,8 @@ snapshots:
     dependencies:
       '@prisma/ppg': 0.5.2
       kysely: 0.29.0
+
+  kysely@0.28.17: {}
 
   kysely@0.29.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
-- ./examples/node-*
+  - ./examples/node-*
 
 allowBuilds:
   better-sqlite3@12.6.0: true
@@ -8,12 +8,15 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
-  '@types/better-sqlite3': 7.6.13
+  "@types/better-sqlite3": 7.6.13
   better-sqlite3: 12.6.0
-  kysely: 0.28.9
+  kysely: 0.29.0
   typescript: 5.9.3
 
 minimumReleaseAge: 1440 # install package versions that are at least 1 day old (in minutes).
+
+minimumReleaseAgeExclude:
+  - kysely@0.29.0
 
 trustPolicy: no-downgrade # fail if there's a regression in attestation of packages.
 

--- a/src/commands/migrate/rollback.mts
+++ b/src/commands/migrate/rollback.mts
@@ -1,5 +1,4 @@
 import { consola } from 'consola'
-import { NO_MIGRATIONS } from 'kysely'
 import { CommonArgs } from '../../arguments/common.mjs'
 import { MigrateArgs } from '../../arguments/migrate.mjs'
 import { processMigrationResultSet } from '../../kysely/process-migration-result-set.mjs'
@@ -25,6 +24,10 @@ const Command = defineCommand(args, {
 	async run(context) {
 		await usingMigrator(context.args, async (migrator) => {
 			consola.start('Starting migration rollback')
+
+			const { NO_MIGRATIONS } = await import('kysely/migration').catch(
+				() => import('kysely') as never as typeof import('kysely/migration'),
+			)
 
 			const resultSet = await migrator.migrateTo(NO_MIGRATIONS)
 

--- a/src/config/kysely-ctl-config.mts
+++ b/src/config/kysely-ctl-config.mts
@@ -3,14 +3,16 @@ import type {
 	Kysely,
 	Dialect as KyselyDialectInstance,
 	KyselyPlugin,
-	MigrationProvider,
-	Migrator,
-	MigratorProps,
 	MssqlDialectConfig,
 	MysqlDialectConfig,
 	PostgresDialectConfig,
 	SqliteDialectConfig,
 } from 'kysely'
+import type {
+	MigrationProvider,
+	Migrator,
+	MigratorProps,
+} from 'kysely/migration'
 import type { NeonDialectConfig } from 'kysely-neon'
 import type { PostgresJSDialectConfig } from 'kysely-postgres-js'
 import type { PPGDialectConfig } from 'kysely-prisma-postgres'

--- a/src/kysely/get-migrations.mts
+++ b/src/kysely/get-migrations.mts
@@ -1,4 +1,4 @@
-import type { MigrationInfo, Migrator } from 'kysely'
+import type { MigrationInfo, Migrator } from 'kysely/migration'
 
 let migrations: readonly MigrationInfo[]
 

--- a/src/kysely/get-migrator.mts
+++ b/src/kysely/get-migrator.mts
@@ -1,4 +1,4 @@
-import { Migrator } from 'kysely'
+import type { Migrator } from 'kysely/migration'
 import type { ResolvedKyselyCTLConfigWithKyselyInstance } from '../config/kysely-ctl-config.mjs'
 import { hydrate } from '../utils/hydrate.mjs'
 import { TSFileMigrationProvider } from './ts-file-migration-provider.mjs'
@@ -25,6 +25,10 @@ export async function getMigrator(
 				filesystemCaching: args['filesystem-caching'],
 				migrationFolder,
 			}),
+	)
+
+	const { Migrator } = await import('kysely/migration').catch(
+		() => import('kysely') as never as typeof import('kysely/migration'),
 	)
 
 	return new Migrator({ ...migratorOptions, db: kysely, provider })

--- a/src/kysely/is-wrong-direction.mts
+++ b/src/kysely/is-wrong-direction.mts
@@ -1,4 +1,4 @@
-import type { Migrator } from 'kysely'
+import type { Migrator } from 'kysely/migration'
 
 // FIXME: we should introduce a way to ensure direction in `migratorTo` @ Kysely core.
 export async function isWrongDirection(

--- a/src/kysely/process-migration-result-set.mts
+++ b/src/kysely/process-migration-result-set.mts
@@ -1,6 +1,6 @@
 import { consola } from 'consola'
 import { colorize } from 'consola/utils'
-import type { MigrationResultSet, Migrator } from 'kysely'
+import type { MigrationResultSet, Migrator } from 'kysely/migration'
 import { assertDefined } from '../utils/assert-defined.mjs'
 import { exitWithError } from '../utils/error.mjs'
 import { getMigrations } from './get-migrations.mjs'

--- a/src/kysely/ts-file-migration-provider.mts
+++ b/src/kysely/ts-file-migration-provider.mts
@@ -1,5 +1,5 @@
 import { consola } from 'consola'
-import type { Migration, MigrationProvider } from 'kysely'
+import type { Migration, MigrationProvider } from 'kysely/migration'
 import { join } from 'pathe'
 import { filename } from 'pathe/utils'
 import { getFileType } from '../utils/get-file-type.mjs'

--- a/src/kysely/using-migrator.mts
+++ b/src/kysely/using-migrator.mts
@@ -1,4 +1,4 @@
-import type { Migrator } from 'kysely'
+import type { Migrator } from 'kysely/migration'
 import { type GetConfigArgs, getConfigOrFail } from '../config/get-config.mjs'
 import { getMigrator } from './get-migrator.mjs'
 import { usingKysely } from './using-kysely.mjs'

--- a/tests/define-config.test-d.ts
+++ b/tests/define-config.test-d.ts
@@ -4,12 +4,12 @@ import {
 	type Dialect,
 	DummyDriver,
 	Kysely,
-	Migrator,
 	PostgresAdapter,
 	PostgresIntrospector,
 	PostgresQueryCompiler,
 	type SqliteDialectConfig,
 } from 'kysely'
+import { Migrator } from 'kysely/migration'
 import { describe, expect, it } from 'vitest'
 import {
 	defineConfig,


### PR DESCRIPTION
Hey 👋 

Starting from `kysely@0.29.0`, migration things are to be imported from `kysely/migration`, not `kysely`.

This PR tries `kysely/migration` first, and falls back to `kysely` for backwards compatibility, when importing migration things.