### PR TITLE
feat: add PGlite dialect support.

### DIFF
--- a/src/config/kysely-ctl-config.mts
+++ b/src/config/kysely-ctl-config.mts
@@ -5,6 +5,7 @@ import type {
 	KyselyPlugin,
 	MssqlDialectConfig,
 	MysqlDialectConfig,
+	PGliteDialectConfig,
 	PostgresDialectConfig,
 	SqliteDialectConfig,
 } from 'kysely'
@@ -26,7 +27,12 @@ export type ResolvableKyselyDialect =
 	| KyselyCoreDialect
 	| KyselyOrganizationDialect
 
-export type KyselyCoreDialect = 'pg' | 'mysql2' | 'tedious' | 'better-sqlite3'
+export type KyselyCoreDialect =
+	| 'pg'
+	| 'mysql2'
+	| 'tedious'
+	| 'better-sqlite3'
+	| 'pglite'
 
 export type KyselyOrganizationDialect =
 	| 'postgres'
@@ -47,6 +53,7 @@ interface KyselyDialectConfigDictionary {
 	bun: PostgresJSDialectConfig
 	mysql2: MysqlDialectConfig
 	pg: PostgresDialectConfig
+	pglite: PGliteDialectConfig
 	postgres: PostgresJSDialectConfig
 	tedious: MssqlDialectConfig
 }

--- a/src/kysely/get-dialect.mts
+++ b/src/kysely/get-dialect.mts
@@ -3,6 +3,7 @@ import {
 	type MssqlDialectConfig,
 	MysqlDialect,
 	type MysqlDialectConfig,
+	type PGliteDialectConfig,
 	PostgresDialect,
 	type PostgresDialectConfig,
 	SqliteDialect,
@@ -47,6 +48,14 @@ export async function getDialect(
 
 	if (dialect === 'better-sqlite3') {
 		return new SqliteDialect(dialectConfig as SqliteDialectConfig)
+	}
+
+	if (dialect === 'pglite') {
+		// since it was introduced only in kysely v0.29.0
+		// and we want to support older versions too
+		return new (await import('kysely')).PGliteDialect(
+			dialectConfig as PGliteDialectConfig,
+		)
 	}
 
 	if (dialect === 'postgres' || dialect === 'bun') {

--- a/tests/define-config.completions.test.ts
+++ b/tests/define-config.completions.test.ts
@@ -13,6 +13,7 @@ describe('defineConfig', () => {
 				'bun',
 				'mysql2',
 				'pg',
+				'pglite',
 				'postgres',
 				'tedious',
 			] satisfies ResolvableKyselyDialect[],


### PR DESCRIPTION
Hey 👋 

`kysely`, starting with `0.29.0` supports a built-in PGlite dialect. This PR adds it to the CLI config options.